### PR TITLE
Add basic yeelink.light.fancl5 support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseTab:          Never

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,8 +168,8 @@ jobs:
       - run: esphome config yeelight_light_ceiling20.yaml
       - run: esphome config yeelight_light_ceilb.yaml
       - run: esphome config yeelight_light_ceilc.yaml
-      - run: esphome config yeelight_light_strip6.yaml
-      - run: esphome config yeerc_ylyk01yl.yaml
+      - run: esphome -s external_components_source components config yeelight_light_strip6.yaml
+      - run: esphome -s external_components_source components config yeerc_ylyk01yl.yaml
 
   esphome-compile:
     runs-on: ubuntu-latest
@@ -216,6 +216,5 @@ jobs:
       - run: esphome compile yeelight_light_ceilb.yaml
       - run: esphome compile yeelight_light_ceilc.yaml
       - run: esphome compile yeelight_light_strip6.yaml
-      - run: |
-          sed -i 's#source: github://syssi/esphome-yeelight-ceiling-light@main#source: components#' yeerc_ylyk01yl.yaml
-          esphome yeerc_ylyk01yl.yaml compile
+      - run: esphome -s external_components_source components yeelight_light_fancl5.yaml
+      - run: esphome -s external_components_source components yeerc_ylyk01yl.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 22.1.0
+    hooks:
+      - id: black
+        args:
+          - --safe
+          - --quiet
+        files: ^((components|esphome|script|tests)/.+)?[^/]+\.py$
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-docstrings==1.5.0
+          - pydocstyle==5.1.1
+        files: ^(components|esphome|tests)/.+\.py$
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+      - id: pyupgrade
+        args: [--py38-plus]
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: clang-format

--- a/components/yeelight_fan_controller/__init__.py
+++ b/components/yeelight_fan_controller/__init__.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["uart", "fan"]
+CODEOWNERS = ["@syssi"]
+MULTI_CONF = True
+
+CONF_YEELIGHT_FAN_CONTROLLER_ID = "yeelight_fan_controller_id"
+
+yeelight_fan_controller_ns = cg.esphome_ns.namespace("yeelight_fan_controller")
+YeelightFanController = yeelight_fan_controller_ns.class_(
+    "YeelightFanController", cg.Component, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(YeelightFanController),
+    }
+).extend(uart.UART_DEVICE_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/components/yeelight_fan_controller/__init__.py
+++ b/components/yeelight_fan_controller/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import uart
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart", "fan"]

--- a/components/yeelight_fan_controller/fan/__init__.py
+++ b/components/yeelight_fan_controller/fan/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import fan
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 from .. import (

--- a/components/yeelight_fan_controller/fan/__init__.py
+++ b/components/yeelight_fan_controller/fan/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fan
+from esphome.const import CONF_ID
+
+from .. import (
+    CONF_YEELIGHT_FAN_CONTROLLER_ID,
+    YeelightFanController,
+    yeelight_fan_controller_ns,
+)
+
+AUTO_LOAD = ["yeelight_fan_controller"]
+
+YeelightFan = yeelight_fan_controller_ns.class_("YeelightFan", cg.Component, fan.Fan)
+
+CONFIG_SCHEMA = fan.FAN_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(YeelightFan),
+        cv.GenerateID(CONF_YEELIGHT_FAN_CONTROLLER_ID): cv.use_id(
+            YeelightFanController
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_YEELIGHT_FAN_CONTROLLER_ID])
+    var = cg.new_Pvariable(config[CONF_ID], hub)
+    await cg.register_component(var, config)
+    await fan.register_fan(var, config)

--- a/components/yeelight_fan_controller/fan/yeelight_fan.cpp
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.cpp
@@ -18,13 +18,9 @@ void YeelightFan::setup() {
   }
 }
 
-void YeelightFan::dump_config() {
-  LOG_FAN("", "YeelightFanController Fan", this);
-}
+void YeelightFan::dump_config() { LOG_FAN("", "YeelightFanController Fan", this); }
 
-fan::FanTraits YeelightFan::get_traits() {
-  return fan::FanTraits(false, true, true, 100);
-}
+fan::FanTraits YeelightFan::get_traits() { return fan::FanTraits(false, true, true, 100); }
 
 void YeelightFan::control(const fan::FanCall &call) {
   if (call.get_state().has_value()) {
@@ -43,9 +39,9 @@ void YeelightFan::control(const fan::FanCall &call) {
 void YeelightFan::write_state_() {
   if (this->state != this->last_state_) {
     if (this->state) {
-      this->parent_->send_command(FUNCTION_TURN_ON, this->speed);
+      this->parent_->send_command(FUNCTION_TURN_ON, 0x13);
     } else {
-      this->parent_->send_command(FUNCTION_TURN_OFF, this->speed);
+      this->parent_->send_command(FUNCTION_TURN_OFF, 0x11);
     }
   }
 
@@ -58,5 +54,5 @@ void YeelightFan::write_state_() {
   }
 }
 
-} // namespace yeelight_fan_controller
-} // namespace esphome
+}  // namespace yeelight_fan_controller
+}  // namespace esphome

--- a/components/yeelight_fan_controller/fan/yeelight_fan.cpp
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.cpp
@@ -1,0 +1,62 @@
+#include "yeelight_fan.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace yeelight_fan_controller {
+
+static const char *const TAG = "yeelight_fan_controller.fan";
+
+static const uint8_t FUNCTION_TURN_OFF = 0x01;
+static const uint8_t FUNCTION_TURN_ON = 0x04;
+static const uint8_t FUNCTION_SET_SPEED = 0x03;
+
+void YeelightFan::setup() {
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(*this);
+    this->write_state_();
+  }
+}
+
+void YeelightFan::dump_config() {
+  LOG_FAN("", "YeelightFanController Fan", this);
+}
+
+fan::FanTraits YeelightFan::get_traits() {
+  return fan::FanTraits(false, true, true, 100);
+}
+
+void YeelightFan::control(const fan::FanCall &call) {
+  if (call.get_state().has_value()) {
+    this->last_state_ = this->state;
+    this->state = *call.get_state();
+  }
+  if (call.get_speed().has_value())
+    this->speed = *call.get_speed();
+  if (call.get_direction().has_value())
+    this->direction = *call.get_direction();
+
+  this->write_state_();
+  this->publish_state();
+}
+
+void YeelightFan::write_state_() {
+  if (this->state != this->last_state_) {
+    if (this->state) {
+      this->parent_->send_command(FUNCTION_TURN_ON, this->speed);
+    } else {
+      this->parent_->send_command(FUNCTION_TURN_OFF, this->speed);
+    }
+  }
+
+  if (this->state) {
+    // if (this->direction == fan::FanDirection::REVERSE) {
+    this->parent_->send_command(FUNCTION_SET_SPEED, this->speed);
+    // } else {
+    //  this->parent_->send_command(FUNCTION_SET_SPEED, this->speed);
+    // }
+  }
+}
+
+} // namespace yeelight_fan_controller
+} // namespace esphome

--- a/components/yeelight_fan_controller/fan/yeelight_fan.h
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.h
@@ -18,7 +18,6 @@ class YeelightFan : public fan::Fan, public Component {
   void control(const fan::FanCall &call) override;
   void write_state_();
 
-  bool last_state_{false};
   YeelightFanController *parent_;
 };
 

--- a/components/yeelight_fan_controller/fan/yeelight_fan.h
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.h
@@ -8,13 +8,13 @@ namespace yeelight_fan_controller {
 
 class YeelightFanController;
 class YeelightFan : public fan::Fan, public Component {
-public:
+ public:
   YeelightFan(YeelightFanController *parent) : parent_(parent) {}
   void setup() override;
   void dump_config() override;
   fan::FanTraits get_traits() override;
 
-protected:
+ protected:
   void control(const fan::FanCall &call) override;
   void write_state_();
 
@@ -22,5 +22,5 @@ protected:
   YeelightFanController *parent_;
 };
 
-} // namespace yeelight_fan_controller
-} // namespace esphome
+}  // namespace yeelight_fan_controller
+}  // namespace esphome

--- a/components/yeelight_fan_controller/fan/yeelight_fan.h
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../yeelight_fan_controller.h"
+#include "esphome/components/fan/fan.h"
+
+namespace esphome {
+namespace yeelight_fan_controller {
+
+class YeelightFanController;
+class YeelightFan : public fan::Fan, public Component {
+public:
+  YeelightFan(YeelightFanController *parent) : parent_(parent) {}
+  void setup() override;
+  void dump_config() override;
+  fan::FanTraits get_traits() override;
+
+protected:
+  void control(const fan::FanCall &call) override;
+  void write_state_();
+
+  bool last_state_{false};
+  YeelightFanController *parent_;
+};
+
+} // namespace yeelight_fan_controller
+} // namespace esphome

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -81,15 +81,13 @@ bool YeelightFanController::parse_yeelight_fan_controller_byte_(uint8_t byte) {
   uint8_t computed_crc = raw[1] + raw[2] + raw[4];
   uint8_t remote_crc = raw[3];
   if (computed_crc != remote_crc) {
-    ESP_LOGW(TAG, "YeelightFanController CRC Check failed! %04X != %04X",
-             computed_crc, remote_crc);
+    ESP_LOGW(TAG, "YeelightFanController CRC Check failed! %04X != %04X", computed_crc, remote_crc);
     return false;
   }
 
   ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at + 1).c_str());
 
-  std::vector<uint8_t> data(this->rx_buffer_.begin(),
-                            this->rx_buffer_.begin() + frame_len);
+  std::vector<uint8_t> data(this->rx_buffer_.begin(), this->rx_buffer_.begin() + frame_len);
 
   this->on_yeelight_fan_controller_data_(data);
 
@@ -97,9 +95,7 @@ bool YeelightFanController::parse_yeelight_fan_controller_byte_(uint8_t byte) {
   return false;
 }
 
-void YeelightFanController::on_yeelight_fan_controller_data_(
-    const std::vector<uint8_t> &data) {
-
+void YeelightFanController::on_yeelight_fan_controller_data_(const std::vector<uint8_t> &data) {
   if (data[1] == FAN_PKT_RESPONSE) {
     if (data[4] == FAN_PKT_INVALID) {
       ESP_LOGE(TAG, "Command failed");
@@ -110,12 +106,10 @@ void YeelightFanController::on_yeelight_fan_controller_data_(
     return;
   }
 
-  ESP_LOGW(TAG, "Unhandled response received: %s",
-           format_hex_pretty(&data.front(), data.size()).c_str());
+  ESP_LOGW(TAG, "Unhandled response received: %s", format_hex_pretty(&data.front(), data.size()).c_str());
 }
 
-void YeelightFanController::
-    dump_config() { // NOLINT(google-readability-function-size,readability-function-size)
+void YeelightFanController::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "YeelightFanController:");
 }
 
@@ -147,5 +141,5 @@ void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
   this->flush();
 }
 
-} // namespace yeelight_fan_controller
-} // namespace esphome
+}  // namespace yeelight_fan_controller
+}  // namespace esphome

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -1,6 +1,7 @@
 #include "yeelight_fan_controller.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
 
 namespace esphome {
 namespace yeelight_fan_controller {
@@ -139,6 +140,8 @@ void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
 
   this->write_array(frame, 6);
   this->flush();
+
+  delay(55);
 }
 
 }  // namespace yeelight_fan_controller

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -118,7 +118,7 @@ float YeelightFanController::get_setup_priority() const {
   return setup_priority::BUS - 1.0f;
 }
 
-void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
+void YeelightFanController::send_command(uint8_t function, uint8_t value) {
   uint8_t frame[6];
 
   // Payload                          Description
@@ -131,8 +131,8 @@ void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
   frame[0] = FAN_PKT_START;
   frame[1] = function;
   frame[2] = 0x01;
-  frame[3] = 0x00;
-  frame[4] = speed;
+  // frame[3] = 0x00;
+  frame[4] = value;
   frame[5] = FAN_PKT_END;
 
   frame[3] = frame[1] + frame[2] + frame[4];

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -1,7 +1,6 @@
 #include "yeelight_fan_controller.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "esphome/core/hal.h"
 
 namespace esphome {
 namespace yeelight_fan_controller {
@@ -140,8 +139,6 @@ void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
 
   this->write_array(frame, 6);
   this->flush();
-
-  delay(55);
 }
 
 }  // namespace yeelight_fan_controller

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -1,0 +1,151 @@
+#include "yeelight_fan_controller.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace yeelight_fan_controller {
+
+static const char *const TAG = "yeelight_fan_controller";
+
+static const uint8_t FAN_PKT_START = 0x01;
+static const uint8_t FAN_PKT_END = 0x03;
+static const uint8_t FAN_PKT_RESPONSE = 0xF3;
+static const uint8_t FAN_PKT_INVALID = 0xA0;
+
+void YeelightFanController::loop() {
+  const uint32_t now = millis();
+
+  if (now - this->last_byte_ > 50) {
+    this->rx_buffer_.clear();
+    this->last_byte_ = now;
+  }
+
+  while (this->available()) {
+    uint8_t byte;
+    this->read_byte(&byte);
+    if (this->parse_yeelight_fan_controller_byte_(byte)) {
+      this->last_byte_ = now;
+    } else {
+      this->rx_buffer_.clear();
+    }
+  }
+}
+
+bool YeelightFanController::parse_yeelight_fan_controller_byte_(uint8_t byte) {
+  size_t at = this->rx_buffer_.size();
+  this->rx_buffer_.push_back(byte);
+  const uint8_t *raw = &this->rx_buffer_[0];
+  uint8_t frame_len = 6;
+
+  // Example traffic
+  //
+  // turn on
+  // >>> 01:04:01:18:13:03
+  // <<< 01:F3:01:07:13:03
+
+  // turn off
+  // >>> 01:01:01:13:11:03
+  // <<< 01:F3:01:05:11:03
+
+  // 1 level / fan speed 1%
+  // >>> 01:03:01:05:01:03
+  // <<< 01:F3:01:F5:01:03
+
+  // 2 level / fan speed 50%
+  // >>> 01:03:01:36:32:03
+  // <<< 01:F3:01:26:32:03
+
+  // 3 level / fan speed 100%
+  // >>> 01:03:01:68:64:03
+  // <<< 01:F3:01:58:64:03
+
+  // Byte Len  Payload                Content              Coeff.      Unit
+  // Example value 0     1   0x01                   Start of frame 1     1 0xF3
+  // Frame type 2     1   0x01                   Unknown 3     1   0x07 Checksum
+  // 4     1   0x13                   Fan speed
+  // 5     1   0x03                   End of frame
+
+  if (at == 0)
+    return true;
+
+  if (raw[0] != FAN_PKT_START) {
+    ESP_LOGW(TAG, "Invalid header");
+
+    // return false to reset buffer
+    return false;
+  }
+
+  if (at < frame_len - 1)
+    return true;
+
+  uint8_t computed_crc = raw[1] + raw[2] + raw[4];
+  uint8_t remote_crc = raw[3];
+  if (computed_crc != remote_crc) {
+    ESP_LOGW(TAG, "YeelightFanController CRC Check failed! %04X != %04X",
+             computed_crc, remote_crc);
+    return false;
+  }
+
+  ESP_LOGVV(TAG, "RX <- %s", format_hex_pretty(raw, at + 1).c_str());
+
+  std::vector<uint8_t> data(this->rx_buffer_.begin(),
+                            this->rx_buffer_.begin() + frame_len);
+
+  this->on_yeelight_fan_controller_data_(data);
+
+  // return false to reset buffer
+  return false;
+}
+
+void YeelightFanController::on_yeelight_fan_controller_data_(
+    const std::vector<uint8_t> &data) {
+
+  if (data[1] == FAN_PKT_RESPONSE) {
+    if (data[4] == FAN_PKT_INVALID) {
+      ESP_LOGE(TAG, "Command failed");
+      return;
+    }
+
+    ESP_LOGI(TAG, "Command successful");
+    return;
+  }
+
+  ESP_LOGW(TAG, "Unhandled response received: %s",
+           format_hex_pretty(&data.front(), data.size()).c_str());
+}
+
+void YeelightFanController::
+    dump_config() { // NOLINT(google-readability-function-size,readability-function-size)
+  ESP_LOGCONFIG(TAG, "YeelightFanController:");
+}
+
+float YeelightFanController::get_setup_priority() const {
+  // After UART bus
+  return setup_priority::BUS - 1.0f;
+}
+
+void YeelightFanController::send_command(uint8_t function, uint8_t speed) {
+  uint8_t frame[6];
+
+  // Payload                          Description
+  // 0x01 0x04 0x01 0x18 0x13 0x03    Turn on
+  // 0x01 0x01 0x01 0x13 0x11 0x03    Turn off
+  // 0x01 0x03 0x01 0x05 0x01 0x03    Fan speed 1%
+  // 0x01 0x03 0x01 0x36 0x32 0x03    Fan speed 50%
+  // 0x01 0x03 0x01 0x68 0x64 0x03    Fan speed 100%
+
+  frame[0] = FAN_PKT_START;
+  frame[1] = function;
+  frame[2] = 0x01;
+  frame[3] = 0x00;
+  frame[4] = speed;
+  frame[5] = FAN_PKT_END;
+
+  frame[3] = frame[1] + frame[2] + frame[4];
+
+  this->write_array(frame, 6);
+  this->flush();
+}
+
+} // namespace yeelight_fan_controller
+} // namespace esphome

--- a/components/yeelight_fan_controller/yeelight_fan_controller.h
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.h
@@ -8,14 +8,14 @@ namespace esphome {
 namespace yeelight_fan_controller {
 
 class YeelightFanController : public uart::UARTDevice, public Component {
-public:
+ public:
   void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
 
   void send_command(uint8_t function, uint8_t speed);
 
-protected:
+ protected:
   std::vector<uint8_t> rx_buffer_;
   uint32_t last_byte_{0};
   uint32_t last_send_{0};
@@ -24,5 +24,5 @@ protected:
   bool parse_yeelight_fan_controller_byte_(uint8_t byte);
 };
 
-} // namespace yeelight_fan_controller
-} // namespace esphome
+}  // namespace yeelight_fan_controller
+}  // namespace esphome

--- a/components/yeelight_fan_controller/yeelight_fan_controller.h
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/components/fan/fan.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace yeelight_fan_controller {
+
+class YeelightFanController : public uart::UARTDevice, public Component {
+public:
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  void send_command(uint8_t function, uint8_t speed);
+
+protected:
+  std::vector<uint8_t> rx_buffer_;
+  uint32_t last_byte_{0};
+  uint32_t last_send_{0};
+
+  void on_yeelight_fan_controller_data_(const std::vector<uint8_t> &data);
+  bool parse_yeelight_fan_controller_byte_(uint8_t byte);
+};
+
+} // namespace yeelight_fan_controller
+} // namespace esphome

--- a/components/yeelight_fan_controller/yeelight_fan_controller.h
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.h
@@ -13,7 +13,7 @@ class YeelightFanController : public uart::UARTDevice, public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  void send_command(uint8_t function, uint8_t speed);
+  void send_command(uint8_t function, uint8_t value);
 
  protected:
   std::vector<uint8_t> rx_buffer_;

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,58 @@
+[flake8]
+max-line-length = 120
+# Following 4 for black compatibility
+# E501: line too long
+# W503: Line break occurred before a binary operator
+# E203: Whitespace before ':'
+# D202 No blank lines allowed after function docstring
+
+# TODO fix flake8
+# D100 Missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+# D105 Missing docstring in magic method
+# D107 Missing docstring in __init__
+# D200 One-line docstring should fit on one line with quotes
+# D205 1 blank line required between summary line and description
+# D209 Multi-line docstring closing quotes should be on a separate line
+# D400 First line should end with a period
+# D401 First line should be in imperative mood
+
+ignore =
+    E501,
+    W503,
+    E203,
+    D202,
+
+    D100,
+    D101,
+    D102,
+    D103,
+    D104,
+    D105,
+    D107,
+    D200,
+    D205,
+    D209,
+    D400,
+    D401,
+
+[isort]
+# https://github.com/timothycrosley/isort
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# splits long import on multiple lines indented by 4 spaces
+multi_line_output = 3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+indent = "    "
+# will group `import x` and `from x import` of the same module.
+force_sort_within_sections = true
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = custom_components,tests
+forced_separate = tests
+combine_as_imports = true

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+esphome -s external_components_source components ${1:-run} ${2:-yeelight_light_fancl5.yaml}

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -1,0 +1,80 @@
+# Yeelight C900 LED Silent Ceiling Fan
+# YLFD002 / YLFD008
+
+substitutions:
+  name: yeelight-light-fancl5
+  external_components_source: github://syssi/esphome-yeelight-ceiling-light@main
+
+esphome:
+  name: ${name}
+
+esp32:
+  board: esp32doit-devkit-v1
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+    advanced:
+      ignore_efuse_mac_crc: true
+
+external_components:
+  - source: ${external_components_source}
+    refresh: 0s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+api:
+logger:
+
+uart:
+  baud_rate: 9600
+  rx_pin: GPIO16
+  tx_pin: GPIO17
+  debug:
+    direction: BOTH
+
+fan:
+  - platform: yeelight_fan_controller
+    name: "${name} ceiling fan"
+
+output:
+  - platform: ledc
+    pin: GPIO19
+    id: output_warm
+  - platform: ledc
+    pin: GPIO21
+    id: output_cold
+  - platform: ledc
+    pin: GPIO23
+    id: output_nightlight
+
+switch:
+  - platform: gpio
+    pin: GPIO33
+    id: buzzer_beep
+    on_turn_on:
+      - delay: 100ms
+      - switch.turn_off: buzzer_beep
+
+light:
+  - platform: monochromatic
+    name: "${name} night light"
+    id: night_light
+    output: output_nightlight
+    gamma_correct: 0
+    on_turn_on:
+      - light.turn_off: ceiling_light
+  - platform: cwww
+    name: "${name} ceiling light"
+    id: ceiling_light
+    cold_white: output_cold
+    warm_white: output_warm
+    cold_white_color_temperature: 6500 K
+    warm_white_color_temperature: 2700 K
+    constant_brightness: true
+    gamma_correct: 0
+    on_turn_on:
+      - light.turn_off: night_light

--- a/yeerc_ylyk01yl.yaml
+++ b/yeerc_ylyk01yl.yaml
@@ -1,5 +1,6 @@
 substitutions:
   name: yeerc
+  external_components_source: github://syssi/esphome-yeelight-ceiling-light@main
 
 esphome:
   name: ${name}
@@ -14,7 +15,7 @@ esp32:
       ignore_efuse_mac_crc: true
 
 external_components:
-  - source: github://syssi/esphome-yeelight-ceiling-light@main
+  - source: ${external_components_source}
     refresh: 0s
 
 wifi:


### PR DESCRIPTION
```
external_components:
  - source: github://syssi/esphome-yeelight-ceiling-light@add-fancl5-support
    refresh: 0s

uart:
  baud_rate: 9600
  rx_pin: GPIO16
  tx_pin: GPIO17
  debug:
    direction: BOTH

fan:
  - platform: yeelight_fan_controller
    name: "${name} ceiling fan"
```