### PR TITLE
YLKG07YL: Add encoder values to trigger actions

### DIFF
--- a/components/xiaomi_ylkg07yl/__init__.py
+++ b/components/xiaomi_ylkg07yl/__init__.py
@@ -32,8 +32,8 @@ SENSORS = [
 CONF_ON_PRESS_AND_ROTATE = "on_press_and_rotate"
 CONF_ON_ROTATE = "on_rotate"
 
-ON_PRESS_ACTIONS = [
-    CONF_ON_PRESS,
+
+ON_ROTATE_ACTIONS = [
     CONF_ON_PRESS_AND_ROTATE,
     CONF_ON_ROTATE,
 ]
@@ -136,7 +136,12 @@ async def to_code(config):
             sens = await sensor.new_sensor(conf)
             cg.add(getattr(var, f"set_{key}_sensor")(sens))
 
-    for action in ON_PRESS_ACTIONS:
+    if CONF_ON_PRESS in config:
+        for conf in config.get(CONF_ON_PRESS, []):
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+            await automation.build_automation(trigger, [(cg.int_, "x")], conf)
+
+    for action in ON_ROTATE_ACTIONS:
         for conf in config.get(action, []):
             trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-            await automation.build_automation(trigger, [], conf)
+            await automation.build_automation(trigger, [(cg.int_, "x")], conf)

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
@@ -59,7 +59,7 @@ bool XiaomiYLKG07YL::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     }
     if (res->keycode.has_value()) {
       if(res->encoder_value.has_value())
-          res->encoder_value = res->encoder_value.value() - 128;
+          res->encoder_value = ((res->encoder_value.value() + 128) % 256 - 128);
 
       if (this->keycode_sensor_ != nullptr)
         this->keycode_sensor_->publish_state(*res->keycode);

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
@@ -58,6 +58,9 @@ bool XiaomiYLKG07YL::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
       continue;
     }
     if (res->keycode.has_value()) {
+      if(res->encoder_value.has_value())
+          res->encoder_value = res->encoder_value.value() - 128;
+
       if (this->keycode_sensor_ != nullptr)
         this->keycode_sensor_->publish_state(*res->keycode);
 

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
@@ -70,7 +70,7 @@ class OnPressAndRotateTrigger : public Trigger<int> {
     a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
       if (action_type == ACTION_TYPE_ROTATE && keycode != KEYCODE_BUTTON) {
 
-        this->trigger(encoder_value);
+        this->trigger(keycode); //for press and rotate, encoder_value is a keycode
       }
     });
   }

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
@@ -41,34 +41,36 @@ class XiaomiYLKG07YL : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   bool decrypt_mibeacon_v23_(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
 };
 
-class OnPressTrigger : public Trigger<> {
+class OnPressTrigger : public Trigger<int> {
  public:
   OnPressTrigger(XiaomiYLKG07YL *a_remote) {
     a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
       if (action_type == ACTION_TYPE_PRESS && keycode == KEYCODE_BUTTON) {
-        this->trigger();
+        this->trigger(encoder_value);
       }
     });
   }
 };
 
-class OnRotateTrigger : public Trigger<> {
+class OnRotateTrigger : public Trigger<int> {
  public:
   OnRotateTrigger(XiaomiYLKG07YL *a_remote) {
     a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
       if (action_type == ACTION_TYPE_ROTATE && keycode == KEYCODE_BUTTON) {
-        this->trigger();
+
+        this->trigger(encoder_value);
       }
     });
   }
 };
 
-class OnPressAndRotateTrigger : public Trigger<> {
+class OnPressAndRotateTrigger : public Trigger<int> {
  public:
   OnPressAndRotateTrigger(XiaomiYLKG07YL *a_remote) {
     a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
       if (action_type == ACTION_TYPE_ROTATE && keycode != KEYCODE_BUTTON) {
-        this->trigger();
+
+        this->trigger(encoder_value);
       }
     });
   }


### PR DESCRIPTION
Closes #112 
Now we can receive encoder values directly from the triggers.
**Breaking change:** encoder values now represents step count, positive for clockwise and negative for counterclockwise.

I am using it like this:
``` yaml
  on_rotate:
    then:
      - light.dim_relative:
          id: cwww_light
          relative_brightness: !lambda return x/10.0;
```

Also i have noticed that for `press_and_rotate` action, the encoder value stored in keycode variable. Maybe we should manage it in the parse_device aswell?
