### PR TITLE
Replace deprecated DEVICE_CLASS_EMPTY and ICON_EMPTY with None

### DIFF
--- a/components/xiaomi_ylkg07yl/__init__.py
+++ b/components/xiaomi_ylkg07yl/__init__.py
@@ -8,8 +8,6 @@ from esphome.const import (
     CONF_MAC_ADDRESS,
     CONF_ON_PRESS,
     CONF_TRIGGER_ID,
-    DEVICE_CLASS_EMPTY,
-    ICON_EMPTY,
     UNIT_EMPTY,
 )
 
@@ -82,21 +80,21 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_BINDKEY): validate_short_bind_key,
             cv.Optional(CONF_KEYCODE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
-                icon=ICON_EMPTY,
+                icon=None,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_EMPTY,
+                device_class=None,
             ),
             cv.Optional(CONF_ENCODER_VALUE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
-                icon=ICON_EMPTY,
+                icon=None,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_EMPTY,
+                device_class=None,
             ),
             cv.Optional(CONF_ACTION_TYPE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
-                icon=ICON_EMPTY,
+                icon=None,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_EMPTY,
+                device_class=None,
             ),
             cv.Optional(CONF_ON_PRESS): automation.validate_automation(
                 {

--- a/components/xiaomi_ylyk01yl/__init__.py
+++ b/components/xiaomi_ylyk01yl/__init__.py
@@ -7,8 +7,6 @@ from esphome.const import (
     CONF_MAC_ADDRESS,
     CONF_ON_PRESS,
     CONF_TRIGGER_ID,
-    DEVICE_CLASS_EMPTY,
-    ICON_EMPTY,
     UNIT_EMPTY,
 )
 
@@ -48,9 +46,9 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_LAST_BUTTON_PRESSED): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
-                icon=ICON_EMPTY,
+                icon=None,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_EMPTY,
+                device_class=None,
             ),
             cv.Optional(CONF_ON_PRESS): automation.validate_automation(
                 {


### PR DESCRIPTION
Replace deprecated `DEVICE_CLASS_EMPTY` and `ICON_EMPTY` constants with `None` and remove them from the `esphome.const` import list.

These constants are deprecated and empty/`None` is the correct replacement per the ESPHome cleanup plan.