### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/xiaomi_ble/__init__.py
+++ b/components/xiaomi_ble/__init__.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["esp32_ble_tracker"]
+CODEOWNERS = ["@syssi"]
 
 xiaomi_ble_ns = cg.esphome_ns.namespace("xiaomi_ble")
 XiaomiListener = xiaomi_ble_ns.class_(

--- a/components/yeelight_fan_controller/fan/__init__.py
+++ b/components/yeelight_fan_controller/fan/__init__.py
@@ -10,6 +10,7 @@ from .. import (
 )
 
 AUTO_LOAD = ["yeelight_fan_controller"]
+CODEOWNERS = ["@syssi"]
 
 YeelightFan = yeelight_fan_controller_ns.class_("YeelightFan", cg.Component, fan.Fan)
 


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `yeelight_fan_controller/fan/__init__.py` and `xiaomi_ble/__init__.py` for consistency with other ESPHome components.