### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/tests/validate-sdkconfig-options.yaml
+++ b/tests/validate-sdkconfig-options.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeedimmer_ylkg07yl.yaml
+++ b/yeedimmer_ylkg07yl.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: esp32doit-devkit-v1

--- a/yeelight_light_ceil26.yaml
+++ b/yeelight_light_ceil26.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceil26.yaml
+++ b/yeelight_light_ceil26.yaml
@@ -35,7 +35,7 @@ api:
 sensor:
   - platform: adc
     pin: GPIO35
-    name: "${name} power supply"
+    name: "power supply"
     attenuation: 12db
 
 output:
@@ -62,14 +62,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_ceil29.yaml
+++ b/yeelight_light_ceil29.yaml
@@ -59,14 +59,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_ceil29.yaml
+++ b/yeelight_light_ceil29.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceila.yaml
+++ b/yeelight_light_ceila.yaml
@@ -12,6 +12,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 external_components:

--- a/yeelight_light_ceila.yaml
+++ b/yeelight_light_ceila.yaml
@@ -48,7 +48,7 @@ api:
 sensor:
   - platform: adc
     pin: GPIO36
-    name: "${name} power supply"
+    name: "power supply"
     attenuation: 12db
     disabled_by_default: true
 
@@ -79,7 +79,7 @@ power_supply:
 
 light:
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm
@@ -93,7 +93,7 @@ light:
         - script.execute: auto_off_timer
     restore_mode: RESTORE_AND_ON
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 1.6
@@ -120,7 +120,7 @@ button:
 number:
   - platform: template
     id: auto_off
-    name: "${name} auto off"
+    name: "auto off"
     initial_value: 0  # Zero means disabled
     min_value: 0
     max_value: 1440  # 24h

--- a/yeelight_light_ceilb.yaml
+++ b/yeelight_light_ceilb.yaml
@@ -72,14 +72,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm
@@ -90,7 +90,7 @@ light:
     on_turn_on:
       - light.turn_off: night_light
   - platform: rgb
-    name: "${name} ambient light"
+    name: "ambient light"
     red: output_red
     green: output_green
     blue: output_blue

--- a/yeelight_light_ceilb.yaml
+++ b/yeelight_light_ceilb.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceilc.yaml
+++ b/yeelight_light_ceilc.yaml
@@ -72,14 +72,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm
@@ -90,7 +90,7 @@ light:
     on_turn_on:
       - light.turn_off: night_light
   - platform: rgb
-    name: "${name} ambient light"
+    name: "ambient light"
     red: output_red
     green: output_green
     blue: output_blue

--- a/yeelight_light_ceilc.yaml
+++ b/yeelight_light_ceilc.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling10.yaml
+++ b/yeelight_light_ceiling10.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling10.yaml
+++ b/yeelight_light_ceiling10.yaml
@@ -74,14 +74,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm
@@ -92,7 +92,7 @@ light:
     on_turn_on:
       - light.turn_off: night_light
   - platform: rgb
-    name: "${name} ambient light"
+    name: "ambient light"
     red: output_red
     green: output_green
     blue: output_blue

--- a/yeelight_light_ceiling11.yaml
+++ b/yeelight_light_ceiling11.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling11.yaml
+++ b/yeelight_light_ceiling11.yaml
@@ -39,11 +39,11 @@ api:
 sensor:
   - platform: adc
     pin: GPIO36
-    name: "${name} adc1"
+    name: "adc1"
     attenuation: 12db
   - platform: adc
     pin: GPIO32
-    name: "${name} adc2"
+    name: "adc2"
     attenuation: 12db
 
 output:

--- a/yeelight_light_ceiling15.yaml
+++ b/yeelight_light_ceiling15.yaml
@@ -35,11 +35,11 @@ api:
 sensor:
   - platform: adc
     pin: GPIO36
-    name: "${name} adc1"
+    name: "adc1"
     attenuation: 12db
   - platform: adc
     pin: GPIO32
-    name: "${name} adc2"
+    name: "adc2"
     attenuation: 12db
 
 output:
@@ -55,14 +55,14 @@ output:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_ceiling15.yaml
+++ b/yeelight_light_ceiling15.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling20.yaml
+++ b/yeelight_light_ceiling20.yaml
@@ -72,14 +72,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm
@@ -90,7 +90,7 @@ light:
     on_turn_on:
       - light.turn_off: night_light
   - platform: rgb
-    name: "${name} ambient light"
+    name: "ambient light"
     red: output_red
     green: output_green
     blue: output_blue

--- a/yeelight_light_ceiling20.yaml
+++ b/yeelight_light_ceiling20.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling22.yaml
+++ b/yeelight_light_ceiling22.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling22.yaml
+++ b/yeelight_light_ceiling22.yaml
@@ -35,7 +35,7 @@ api:
 sensor:
   - platform: adc
     pin: GPIO36
-    name: "${name} power supply"
+    name: "power supply"
     attenuation: 12db
 
 output:
@@ -67,14 +67,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_ceiling24.yaml
+++ b/yeelight_light_ceiling24.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_ceiling24.yaml
+++ b/yeelight_light_ceiling24.yaml
@@ -38,11 +38,11 @@ api:
 sensor:
   - platform: adc
     pin: GPIO32
-    name: "${name} adc1"
+    name: "adc1"
     attenuation: 12db
   - platform: adc
     pin: GPIO33
-    name: "${name} adc2"
+    name: "adc2"
     attenuation: 12db
 
 output:
@@ -55,7 +55,7 @@ output:
 
 light:
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -59,7 +59,7 @@ uart:
 fan:
   - platform: yeelight_fan_controller
     id: yeelight_ceiling_fan
-    name: "${name} ceiling fan"
+    name: "ceiling fan"
 
 output:
   - platform: ledc
@@ -82,14 +82,14 @@ switch:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: ceiling_light
   - platform: cwww
-    name: "${name} ceiling light"
+    name: "ceiling light"
     id: ceiling_light
     cold_white: output_cold
     warm_white: output_warm

--- a/yeelight_light_lamp9.yaml
+++ b/yeelight_light_lamp9.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_lamp9.yaml
+++ b/yeelight_light_lamp9.yaml
@@ -37,7 +37,7 @@ binary_sensor:
     pin:
       number: GPIO14
       inverted: true
-    name: "${name} button"
+    name: "button"
     id: button
     on_click:
       then:
@@ -105,14 +105,14 @@ power_supply:
 
 light:
   - platform: monochromatic
-    name: "${name} night light"
+    name: "night light"
     id: night_light
     output: output_nightlight
     gamma_correct: 0
     on_turn_on:
       - light.turn_off: bedside_light
   - platform: cwww
-    name: "${name} bedside light"
+    name: "bedside light"
     id: bedside_light
     cold_white: output_cold
     warm_white: output_warm
@@ -123,7 +123,7 @@ light:
     on_turn_on:
       - light.turn_off: night_light
   - platform: binary
-    name: "${name} mainboard led"
+    name: "mainboard led"
     output: led_output
 
 # A eeprom at address 0x10 should be found.

--- a/yeelight_light_strip6.yaml
+++ b/yeelight_light_strip6.yaml
@@ -3,6 +3,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeelight_light_strip6.yaml
+++ b/yeelight_light_strip6.yaml
@@ -36,7 +36,7 @@ binary_sensor:
   - platform: gpio
     pin:
       number: GPIO19
-    name: "${name} button"
+    name: "button"
     on_press:
       - light.toggle: light0
 
@@ -54,7 +54,7 @@ output:
 light:
   - platform: rgb
     id: light0
-    name: "${name} rgb"
+    name: "rgb"
     red: output_red
     green: output_green
     blue: output_blue

--- a/yeerc_ylyk01yl.yaml
+++ b/yeerc_ylyk01yl.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:

--- a/yeerc_ylyk01yl_fancl.yaml
+++ b/yeerc_ylyk01yl_fancl.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   min_version: 2024.10.0
 
 esp32:


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.