### PR TITLE
Migrate xiaomi_ylkg07yl triggers to callback automation

### DIFF
--- a/components/xiaomi_ylkg07yl/__init__.py
+++ b/components/xiaomi_ylkg07yl/__init__.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_ON_PRESS,
-    CONF_TRIGGER_ID,
     DEVICE_CLASS_EMPTY,
     ICON_EMPTY,
     UNIT_EMPTY,
@@ -41,18 +40,6 @@ ON_PRESS_ACTIONS = [
 xiaomi_ylkg07yl_ns = cg.esphome_ns.namespace("xiaomi_ylkg07yl")
 XiaomiYLKG07YL = xiaomi_ylkg07yl_ns.class_(
     "XiaomiYLKG07YL", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
-)
-
-OnPressTrigger = xiaomi_ylkg07yl_ns.class_(
-    "OnPressTrigger", automation.Trigger.template()
-)
-
-OnPressAndRotateTrigger = xiaomi_ylkg07yl_ns.class_(
-    "OnPressAndRotateTrigger", automation.Trigger.template()
-)
-
-OnRotateTrigger = xiaomi_ylkg07yl_ns.class_(
-    "OnRotateTrigger", automation.Trigger.template()
 )
 
 
@@ -98,23 +85,9 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_EMPTY,
             ),
-            cv.Optional(CONF_ON_PRESS): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnPressTrigger),
-                }
-            ),
-            cv.Optional(CONF_ON_PRESS_AND_ROTATE): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                        OnPressAndRotateTrigger
-                    ),
-                }
-            ),
-            cv.Optional(CONF_ON_ROTATE): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnRotateTrigger),
-                }
-            ),
+            cv.Optional(CONF_ON_PRESS): automation.validate_automation({}),
+            cv.Optional(CONF_ON_PRESS_AND_ROTATE): automation.validate_automation({}),
+            cv.Optional(CONF_ON_ROTATE): automation.validate_automation({}),
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
@@ -136,7 +109,13 @@ async def to_code(config):
             sens = await sensor.new_sensor(conf)
             cg.add(getattr(var, f"set_{key}_sensor")(sens))
 
-    for action in ON_PRESS_ACTIONS:
+    callback_map = {
+        CONF_ON_PRESS: ("add_on_press_callback", cg.int_),
+        CONF_ON_ROTATE: ("add_on_rotate_callback", cg.int_),
+        CONF_ON_PRESS_AND_ROTATE: ("add_on_press_and_rotate_callback", cg.int_),
+    }
+    for action, (callback_name, arg_type) in callback_map.items():
         for conf in config.get(action, []):
-            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-            await automation.build_automation(trigger, [(cg.int_, "x")], conf)
+            await automation.build_callback_automation(
+                var, callback_name, [(arg_type, "x")], conf
+            )

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
@@ -70,8 +70,14 @@ bool XiaomiYLKG07YL::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
       if (this->action_type_sensor_ != nullptr && res->action_type.has_value())
         this->action_type_sensor_->publish_state(*res->action_type);
 
-      if (res->encoder_value.has_value() && res->action_type.has_value())
-        this->receive_callback_.call(*res->keycode, *res->encoder_value, *res->action_type);
+      if (res->encoder_value.has_value() && res->action_type.has_value()) {
+        if (*res->action_type == ACTION_TYPE_PRESS && *res->keycode == KEYCODE_BUTTON)
+          this->press_callback_.call(*res->encoder_value);
+        if (*res->action_type == ACTION_TYPE_ROTATE && *res->keycode == KEYCODE_BUTTON)
+          this->rotate_callback_.call(*res->encoder_value);
+        if (*res->action_type == ACTION_TYPE_ROTATE && *res->keycode != KEYCODE_BUTTON)
+          this->press_and_rotate_callback_.call(*res->keycode);
+      }
     }
     success = true;
   }
@@ -89,10 +95,6 @@ void XiaomiYLKG07YL::set_bindkey(const std::string &bindkey) {
     strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
     bindkey_[i] = std::strtoul(temp, nullptr, 16);
   }
-}
-
-void XiaomiYLKG07YL::add_on_receive_callback(std::function<void(int, int, int)> &&callback) {
-  this->receive_callback_.add(std::move(callback));
 }
 
 // Decrypt MiBeacon V2/V3 payload

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
@@ -28,7 +28,11 @@ class XiaomiYLKG07YL : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   void set_keycode_sensor(sensor::Sensor *keycode_sensor) { keycode_sensor_ = keycode_sensor; }
   void set_encoder_value_sensor(sensor::Sensor *encoder_value_sensor) { encoder_value_sensor_ = encoder_value_sensor; }
   void set_action_type_sensor(sensor::Sensor *action_type_sensor) { action_type_sensor_ = action_type_sensor; }
-  void add_on_receive_callback(std::function<void(int, int, int)> &&callback);
+  void add_on_press_callback(std::function<void(int)> &&callback) { this->press_callback_.add(std::move(callback)); }
+  void add_on_rotate_callback(std::function<void(int)> &&callback) { this->rotate_callback_.add(std::move(callback)); }
+  void add_on_press_and_rotate_callback(std::function<void(int)> &&callback) {
+    this->press_and_rotate_callback_.add(std::move(callback));
+  }
 
  protected:
   uint64_t address_;
@@ -36,42 +40,11 @@ class XiaomiYLKG07YL : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   sensor::Sensor *keycode_sensor_{nullptr};
   sensor::Sensor *encoder_value_sensor_{nullptr};
   sensor::Sensor *action_type_sensor_{nullptr};
-  CallbackManager<void(int, int, int)> receive_callback_{};
+  CallbackManager<void(int)> press_callback_{};
+  CallbackManager<void(int)> rotate_callback_{};
+  CallbackManager<void(int)> press_and_rotate_callback_{};
 
   bool decrypt_mibeacon_v23_(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
-};
-
-class OnPressTrigger : public Trigger<int> {
- public:
-  OnPressTrigger(XiaomiYLKG07YL *a_remote) {
-    a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
-      if (action_type == ACTION_TYPE_PRESS && keycode == KEYCODE_BUTTON) {
-        this->trigger(encoder_value);
-      }
-    });
-  }
-};
-
-class OnRotateTrigger : public Trigger<int> {
- public:
-  OnRotateTrigger(XiaomiYLKG07YL *a_remote) {
-    a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
-      if (action_type == ACTION_TYPE_ROTATE && keycode == KEYCODE_BUTTON) {
-        this->trigger(encoder_value);
-      }
-    });
-  }
-};
-
-class OnPressAndRotateTrigger : public Trigger<int> {
- public:
-  OnPressAndRotateTrigger(XiaomiYLKG07YL *a_remote) {
-    a_remote->add_on_receive_callback([this](int keycode, int encoder_value, int action_type) {
-      if (action_type == ACTION_TYPE_ROTATE && keycode != KEYCODE_BUTTON) {
-        this->trigger(keycode);  // for press and rotate, encoder_value is a keycode
-      }
-    });
-  }
 };
 
 }  // namespace xiaomi_ylkg07yl


### PR DESCRIPTION
## Summary

Replaces the three `Trigger<int>` subclasses (`OnPressTrigger`, `OnRotateTrigger`, `OnPressAndRotateTrigger`) in `xiaomi_ylkg07yl` with typed `CallbackManager` members directly on `XiaomiYLKG07YL`:

- `add_on_press_callback` — fires when `action_type == PRESS && keycode == BUTTON`
- `add_on_rotate_callback` — fires when `action_type == ROTATE && keycode == BUTTON`
- `add_on_press_and_rotate_callback` — fires when `action_type == ROTATE && keycode != BUTTON`

The filtering logic moves from the trigger constructors into `parse_device()`. The Python side uses `build_callback_automation` instead of the old `build_automation` + trigger heap allocation.

Mirrors the ESPHome core trigger migration pattern (#15197–#15233).

**Note:** `xiaomi_ylyk01yl` retains its `Trigger<uint8_t>` subclasses intentionally — the per-trigger `keycode:` filter option has no direct equivalent in `build_callback_automation`.

## Test plan

- [x] Verify `on_press`, `on_rotate`, `on_press_and_rotate` automations fire correctly with a YLKG07YL remote