### PR TITLE
Align code style with ESPHome core

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -38,21 +38,3 @@ ignore =
     D209,
     D400,
     D401,
-
-[isort]
-# https://github.com/timothycrosley/isort
-# https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_first_party = custom_components,tests
-forced_separate = tests
-combine_as_imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,15 +41,6 @@ repos:
         args: [--persistent=n, components]
         pass_filenames: false
         additional_dependencies: [esphome]
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: pytest
-        language: python
-        types: [python]
-        pass_filenames: false
-        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,13 @@
 # See https://pre-commit.com/hooks.html for more hooks
 # See https://github.com/rytilahti/python-miio/blob/master/.pre-commit-config.yaml
 repos:
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-      - id: isort
+      - id: no-commit-to-branch
+        args: [--branch=main]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.5.5
@@ -15,13 +18,6 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.0
     hooks:
@@ -38,6 +34,22 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.3.4
+    hooks:
+      - id: pylint
+        args: [--persistent=n, components]
+        pass_filenames: false
+        additional_dependencies: [esphome]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: python
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ESPHome custom firmware for ESP32 based Yeelight Ceiling Lights.
 - Light strip (RGB)
   - Brightness
   - Color
- 
+
 ### yeelink.light.ceiling24
 
 - Light (CCWW)
@@ -675,7 +675,7 @@ When flashing the YLXDD-00xx series you'll need an external 3.3V power supply an
 
 ### YLXD62YI
 Rotate the cover counterclockwise to remove the cover. Unscrew the 220VAC L and N Wires. Remove three screws on the transparent diffusor.
-Now the PCB is completely exposed and unmounted from the base. 
+Now the PCB is completely exposed and unmounted from the base.
 3.3V, GND, TXD, RXD and IO0 Pads are clearly visible on the main PCB near ESP32 board.
 To flash ESP32 you need to solder the wires onto that test points.
 

--- a/logs/ceil26-flash.txt
+++ b/logs/ceil26-flash.txt
@@ -12,9 +12,9 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing livingroom_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Looking for AsyncTCP-esphome library in registry
 LibraryManager: Installing id=6798 @ 1.1.1
@@ -149,10 +149,10 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing livingroom_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
- - tool-mkspiffs 2.230.0 (2.30) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
+ - tool-mkspiffs 2.230.0 (2.30)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Dependency Graph
 |-- <AsyncTCP-esphome> 1.1.1

--- a/logs/ceil26-ylxd76yl-flash.txt
+++ b/logs/ceil26-ylxd76yl-flash.txt
@@ -1,4 +1,4 @@
-$ ~/.local/bin/esphome unused_yeelight.yaml run   
+$ ~/.local/bin/esphome unused_yeelight.yaml run
 INFO Reading configuration unused_yeelight.yaml...
 INFO Generating C++ source...
 INFO Core config or version changed, cleaning build files...
@@ -12,9 +12,9 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing unused_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Looking for AsyncTCP-esphome library in registry
 LibraryManager: Installing id=6798 @ 1.1.1
@@ -153,9 +153,9 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing unused_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Dependency Graph
 |-- <AsyncTCP-esphome> 1.1.1
@@ -182,10 +182,10 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing unused_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
- - tool-mkspiffs 2.230.0 (2.30) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
+ - tool-mkspiffs 2.230.0 (2.30)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Dependency Graph
 |-- <AsyncTCP-esphome> 1.1.1
@@ -268,4 +268,3 @@ Hard resetting via RTS pin...
 ============================================================================================== [SUCCESS] Took 48.79 seconds ==============================================================================================
 INFO Successfully uploaded program.
 INFO Starting log output from /dev/ttyUSB0 with baud rate 115200
-

--- a/logs/ceiling10-flash.txt
+++ b/logs/ceiling10-flash.txt
@@ -2,10 +2,10 @@ INFO Running:  platformio run -d diningroom_yeelight -t upload --upload-port /de
 Processing diningroom_yeelight (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@3.0.0)
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 0.0.0 
- - tool-esptoolpy 1.30000.201119 (3.0.0) 
- - tool-mkspiffs 2.230.0 (2.30) 
+PACKAGES:
+ - framework-arduinoespressif32 0.0.0
+ - tool-esptoolpy 1.30000.201119 (3.0.0)
+ - tool-mkspiffs 2.230.0 (2.30)
  - toolchain-xtensa32 2.50200.97 (5.2.0)
 Library Manager: Installing Hash
 Library Manager: Already installed, built-in library

--- a/logs/ceiling10-stock-firmware.txt
+++ b/logs/ceiling10-stock-firmware.txt
@@ -37,7 +37,7 @@ load:0x3fff001c,len:988
 load:0x40078000,len:0
 load:0x40078000,len:12024
 csum err:0xf0!=0x63
-ets_main.c 371 
+ets_main.c 371
 ets Jun  8 2016 00:22:57
 
 rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
@@ -56,16 +56,16 @@ I (28) boot: SPI Flash  ID  : 0x200B
 08:00:00.090 [I] miio_ot: dlg disabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Apr 15 2020,18:28:48
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0049
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 305748866
 MIIO WIFI MAC: 5cXXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling10
@@ -92,16 +92,16 @@ I (28) boot: SPI Flash  ID  : 0x200B
 08:00:00.090 [I] miio_ot: dlg disabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Apr 15 2020,18:28:48
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0049
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 305748866
 MIIO WIFI MAC: 5cXXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling10

--- a/logs/ceiling15-flash.txt
+++ b/logs/ceiling15-flash.txt
@@ -13,10 +13,10 @@ https://docs.platformio.org/page/faq.html#multiple-pio-cores-in-a-system
 Processing yeelight_light_ceiling15 (board: esp32doit-devkit-v1; framework: arduino; platform: espressif32@1.11.0)
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
-PACKAGES: 
- - framework-arduinoespressif32 49b5f52 
- - tool-esptoolpy 1.20600.0 (2.6.0) 
- - tool-mkspiffs 2.230.0 (2.30) 
+PACKAGES:
+ - framework-arduinoespressif32 49b5f52
+ - tool-esptoolpy 1.20600.0 (2.6.0)
+ - tool-mkspiffs 2.230.0 (2.30)
  - toolchain-xtensa32 2.50200.80 (5.2.0)
 Dependency Graph
 |-- <AsyncTCP-esphome> 1.1.1

--- a/logs/ceiling15-stock-firmware.txt
+++ b/logs/ceiling15-stock-firmware.txt
@@ -30,16 +30,16 @@ entry 0x40078c08
 08:00:00.270 [I] miio_ot: dlg enabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Nov 27 2020,09:33:16
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0026
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 270166479
 MIIO WIFI MAC: 50XXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling15
@@ -411,16 +411,16 @@ entry 0x40078c08
 08:00:00.470 [I] miio_ot: dlg enabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Nov 27 2020,09:33:16
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0026
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 270166479
 MIIO WIFI MAC: 50XXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling15
@@ -480,16 +480,16 @@ entry 0x40078c08
 08:00:00.160 [I] miio_ot: dlg enabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Nov 27 2020,09:33:16
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0026
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 270166479
 MIIO WIFI MAC: 50XXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling15
@@ -554,16 +554,16 @@ entry 0x40078c08
 08:00:00.170 [I] miio_ot: dlg enabled
 
 
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 _|_|  _|_|    _|      _|    _|    _|
 _|  _|  _|    _|      _|    _|    _|
 _|      _|    _|      _|    _|    _|
-_|      _|  _|_|_|  _|_|_|    _|_|  
+_|      _|  _|_|_|  _|_|_|    _|_|
 JENKINS BUILD NUMBER: N/A
 BUILD TIME: Nov 27 2020,09:33:16
 BUILT BY: N/A
 MIIO APP VER: 2.0.6_0026
-MIIO MCU VER: 
+MIIO MCU VER:
 MIIO DID: 270166479
 MIIO WIFI MAC: 50XXXXXXXXXX
 MIIO MODEL: yeelink.light.ceiling15

--- a/logs/download-mode-gpio0.txt
+++ b/logs/download-mode-gpio0.txt
@@ -1,4 +1,3 @@
 rst:0x1 (POWERON_RESET),boot:0x3 (DOWNLOAD_BOOT(UART0/UART1/SDIO_REI_REO_V2))
 
 waiting for download
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ disable = [
   "stop-iteration-return",
   "import-outside-toplevel",
   # Broken
+  "no-name-in-module",
   "unsupported-membership-test",
   "unsubscriptable-object",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[tool.pylint.MAIN]
+py-version = "3.11"
+persistent = false
+
+[tool.pylint.REPORTS]
+score = false
+
+[tool.pylint."MESSAGES CONTROL"]
+# Mirrors ESPHome's pyproject.toml
+disable = [
+  "format",
+  "missing-docstring",
+  "fixme",
+  "unused-argument",
+  "global-statement",
+  "too-few-public-methods",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-ancestors",
+  "too-many-branches",
+  "too-many-statements",
+  "too-many-arguments",
+  "too-many-positional-arguments",
+  "too-many-return-statements",
+  "too-many-instance-attributes",
+  "duplicate-code",
+  "invalid-name",
+  "cyclic-import",
+  "redefined-builtin",
+  "undefined-loop-variable",
+  "useless-object-inheritance",
+  "stop-iteration-return",
+  "import-outside-toplevel",
+  # Broken
+  "unsupported-membership-test",
+  "unsubscriptable-object",
+]
+
+[tool.pylint.FORMAT]
+expected-line-ending-format = "LF"
+
+[tool.ruff]
+required-version = ">=0.5.0"
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle
+  "F",    # pyflakes/autoflake
+  "FURB", # refurb
+  "I",    # isort
+  "PERF", # performance
+  "PL",   # pylint
+  "SIM",  # flake8-simplify
+  "RET",  # flake8-ret
+  "UP",   # pyupgrade
+]
+
+ignore = [
+  "E501",    # line too long
+  "PLC0415", # `import` should be at the top-level of a file
+  "PLR0911", # Too many return statements
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments to function call
+  "PLR0915", # Too many statements
+  "PLW1641", # Object does not implement `__hash__` method
+  "PLR2004", # Magic value used in comparison
+  "PLW2901", # Outer variable overwritten by inner target
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["components"]
+combine-as-imports = true
+split-on-trailing-comma = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ disable = [
   "useless-object-inheritance",
   "stop-iteration-return",
   "import-outside-toplevel",
+  "no-member",
   # Broken
   "no-name-in-module",
   "unsupported-membership-test",


### PR DESCRIPTION
## Summary

- Replace `setup.cfg` (flake8 + isort) with `pyproject.toml` and `.flake8`
- Migrate pylint config to `pyproject.toml`, mirroring ESPHome core settings
- Update ruff rules to match ESPHome core (`FURB`, `PERF`, `PL`, `SIM`, `RET`)
- Remove standalone `isort` and `black` hooks — replaced by `ruff` and `ruff-format`
- Add `pre-commit-hooks`: `no-commit-to-branch`, `end-of-file-fixer`, `trailing-whitespace`
- Add `pylint` pre-commit hook

## References

- ESPHome core: [pyproject.toml](https://github.com/esphome/esphome/blob/dev/pyproject.toml)
- Reference PR: syssi/esphome-daly-bms#86
