### PR TITLE
Extend CONFIG_SCHEMA with cv.COMPONENT_SCHEMA

### DIFF
--- a/components/yeelight_fan_controller/__init__.py
+++ b/components/yeelight_fan_controller/__init__.py
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(YeelightFanController),
     }
-).extend(uart.UART_DEVICE_SCHEMA)
+).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):

--- a/components/yeelight_fan_controller/__init__.py
+++ b/components/yeelight_fan_controller/__init__.py
@@ -16,11 +16,15 @@ YeelightFanController = yeelight_fan_controller_ns.class_(
     "YeelightFanController", cg.Component, uart.UARTDevice
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(YeelightFanController),
-    }
-).extend(uart.UART_DEVICE_SCHEMA).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(YeelightFanController),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
## Summary

`YeelightFanController` inherits from `cg.Component` and its `to_code` calls `register_component()`, but `CONFIG_SCHEMA` was missing `.extend(cv.COMPONENT_SCHEMA)`.

Without it the `setup_priority` key is not accepted in YAML configuration.

## Root cause

`uart.UART_DEVICE_SCHEMA` only provides the parent UART reference — it does not include `cv.COMPONENT_SCHEMA`. Components that use UART as a bus must add `cv.COMPONENT_SCHEMA` (or `cv.polling_component_schema`) explicitly.