### PR TITLE
Add component schema tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -396,6 +396,30 @@ jobs:
         # yamllint disable-line rule:line-length
         if: always()
 
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-24.04
+    needs:
+      - bundle
+      - common
+    steps:
+      - name: Download prepared repository
+        uses: pyTooling/download-artifact@v4
+        with:
+          name: bundle
+          path: .
+
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Run pytest
+        run: |
+          . venv/bin/activate
+          pytest tests/ -v
+
   esphome-config:
     name: Validate example configurations
     runs-on: ubuntu-24.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,15 @@ repos:
         args: [--persistent=n, components]
         pass_filenames: false
         additional_dependencies: [esphome]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: python
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -1,0 +1,34 @@
+"""Schema structure tests for yeelight_ceiling_light ESPHome component modules."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import components.xiaomi_ylkg07yl as ylkg07yl  # noqa: E402
+import components.xiaomi_ylyk01yl as ylyk01yl  # noqa: E402
+import components.yeelight_fan_controller as hub  # noqa: E402
+
+
+class TestHubConstants:
+    def test_conf_yeelight_fan_controller_id_defined(self):
+        assert hub.CONF_YEELIGHT_FAN_CONTROLLER_ID == "yeelight_fan_controller_id"
+
+
+class TestYlkg07ylConstants:
+    def test_sensors_list(self):
+        assert ylkg07yl.CONF_KEYCODE in ylkg07yl.SENSORS
+        assert ylkg07yl.CONF_ENCODER_VALUE in ylkg07yl.SENSORS
+        assert ylkg07yl.CONF_ACTION_TYPE in ylkg07yl.SENSORS
+        assert len(ylkg07yl.SENSORS) == 3
+
+    def test_on_press_actions_list(self):
+        assert ylkg07yl.CONF_ON_PRESS_AND_ROTATE in ylkg07yl.ON_PRESS_ACTIONS
+        assert ylkg07yl.CONF_ON_ROTATE in ylkg07yl.ON_PRESS_ACTIONS
+        assert len(ylkg07yl.ON_PRESS_ACTIONS) == 3
+
+
+class TestYlyk01ylConstants:
+    def test_on_press_actions_list(self):
+        assert ylyk01yl.CONF_ON_LONG_PRESS in ylyk01yl.ON_PRESS_ACTIONS
+        assert len(ylyk01yl.ON_PRESS_ACTIONS) == 2


### PR DESCRIPTION
## Summary
- Add `tests/test_component_schemas.py` with schema structure tests for all component modules
- Add pytest hook to `.pre-commit-config.yaml`
- Add pytest job to CI workflow

## Test plan
- [x] All existing tests pass
- [x] New pytest job passes in CI