### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/components/xiaomi_ble/xiaomi_ble.cpp
@@ -7,8 +7,7 @@
 #include <vector>
 #include "mbedtls/ccm.h"
 
-namespace esphome {
-namespace xiaomi_ble {
+namespace esphome::xiaomi_ble {
 
 static const char *const TAG = "xiaomi_ble";
 
@@ -446,7 +445,6 @@ bool XiaomiListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return false;  // with true it's not showing device scans
 }
 
-}  // namespace xiaomi_ble
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ble
 
 #endif

--- a/components/xiaomi_ble/xiaomi_ble.h
+++ b/components/xiaomi_ble/xiaomi_ble.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_ble {
+namespace esphome::xiaomi_ble {
 
 struct XiaomiParseResult {
   enum {
@@ -85,7 +84,6 @@ class XiaomiListener : public esp32_ble_tracker::ESPBTDeviceListener {
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 };
 
-}  // namespace xiaomi_ble
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ble
 
 #endif

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.cpp
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_ylkg07yl {
+namespace esphome::xiaomi_ylkg07yl {
 
 static const char *const TAG = "xiaomi_ylkg07yl";
 
@@ -220,7 +219,6 @@ bool XiaomiYLKG07YL::decrypt_mibeacon_v23_(std::vector<uint8_t> &raw, const uint
   return true;
 }
 
-}  // namespace xiaomi_ylkg07yl
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ylkg07yl
 
 #endif

--- a/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
+++ b/components/xiaomi_ylkg07yl/xiaomi_ylkg07yl.h
@@ -13,8 +13,7 @@ static const uint8_t KEYCODE_BUTTON = 0;
 static const uint8_t ACTION_TYPE_PRESS = 3;
 static const uint8_t ACTION_TYPE_ROTATE = 4;
 
-namespace esphome {
-namespace xiaomi_ylkg07yl {
+namespace esphome::xiaomi_ylkg07yl {
 
 class XiaomiYLKG07YL : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -47,7 +46,6 @@ class XiaomiYLKG07YL : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   bool decrypt_mibeacon_v23_(std::vector<uint8_t> &raw, const uint8_t *bindkey, const uint64_t &address);
 };
 
-}  // namespace xiaomi_ylkg07yl
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ylkg07yl
 
 #endif

--- a/components/xiaomi_ylyk01yl/xiaomi_ylyk01yl.cpp
+++ b/components/xiaomi_ylyk01yl/xiaomi_ylyk01yl.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_ylyk01yl {
+namespace esphome::xiaomi_ylyk01yl {
 
 static const char *const TAG = "xiaomi_ylyk01yl";
 
@@ -57,7 +56,6 @@ void XiaomiYLYK01YL::add_on_receive_callback(std::function<void(uint8_t, bool)> 
   this->receive_callback_.add(std::move(callback));
 }
 
-}  // namespace xiaomi_ylyk01yl
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ylyk01yl
 
 #endif

--- a/components/xiaomi_ylyk01yl/xiaomi_ylyk01yl.h
+++ b/components/xiaomi_ylyk01yl/xiaomi_ylyk01yl.h
@@ -8,8 +8,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace xiaomi_ylyk01yl {
+namespace esphome::xiaomi_ylyk01yl {
 
 // static const uint8_t BUTTON_ON = 0;
 // static const uint8_t BUTTON_OFF = 1;
@@ -79,7 +78,6 @@ class OnLongPressTrigger : public Trigger<uint8_t> {
   uint8_t keycode_ = 255;
 };
 
-}  // namespace xiaomi_ylyk01yl
-}  // namespace esphome
+}  // namespace esphome::xiaomi_ylyk01yl
 
 #endif

--- a/components/yeelight_fan_controller/fan/yeelight_fan.cpp
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace yeelight_fan_controller {
+namespace esphome::yeelight_fan_controller {
 
 static const char *const TAG = "yeelight_fan_controller.fan";
 
@@ -59,5 +58,4 @@ void YeelightFan::write_state_() {
   }
 }
 
-}  // namespace yeelight_fan_controller
-}  // namespace esphome
+}  // namespace esphome::yeelight_fan_controller

--- a/components/yeelight_fan_controller/fan/yeelight_fan.h
+++ b/components/yeelight_fan_controller/fan/yeelight_fan.h
@@ -3,8 +3,7 @@
 #include "../yeelight_fan_controller.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace yeelight_fan_controller {
+namespace esphome::yeelight_fan_controller {
 
 class YeelightFanController;
 class YeelightFan : public fan::Fan, public Component {
@@ -21,5 +20,4 @@ class YeelightFan : public fan::Fan, public Component {
   YeelightFanController *parent_;
 };
 
-}  // namespace yeelight_fan_controller
-}  // namespace esphome
+}  // namespace esphome::yeelight_fan_controller

--- a/components/yeelight_fan_controller/yeelight_fan_controller.cpp
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace yeelight_fan_controller {
+namespace esphome::yeelight_fan_controller {
 
 static const char *const TAG = "yeelight_fan_controller";
 
@@ -144,5 +143,4 @@ void YeelightFanController::send_command(uint8_t function, uint8_t value) {
   this->flush();
 }
 
-}  // namespace yeelight_fan_controller
-}  // namespace esphome
+}  // namespace esphome::yeelight_fan_controller

--- a/components/yeelight_fan_controller/yeelight_fan_controller.h
+++ b/components/yeelight_fan_controller/yeelight_fan_controller.h
@@ -4,8 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace yeelight_fan_controller {
+namespace esphome::yeelight_fan_controller {
 
 class YeelightFanController : public uart::UARTDevice, public Component {
  public:
@@ -24,5 +23,4 @@ class YeelightFanController : public uart::UARTDevice, public Component {
   bool parse_yeelight_fan_controller_byte_(uint8_t byte);
 };
 
-}  // namespace yeelight_fan_controller
-}  // namespace esphome
+}  // namespace esphome::yeelight_fan_controller


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.