### PR TITLE
Add min_auth_mode: WPA2 to wifi configuration

### DIFF
--- a/yeedimmer_ylkg07yl.yaml
+++ b/yeedimmer_ylkg07yl.yaml
@@ -20,6 +20,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceil26.yaml
+++ b/yeelight_light_ceil26.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceil29.yaml
+++ b/yeelight_light_ceil29.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceila.yaml
+++ b/yeelight_light_ceila.yaml
@@ -36,6 +36,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceilb.yaml
+++ b/yeelight_light_ceilb.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceilc.yaml
+++ b/yeelight_light_ceilc.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling10.yaml
+++ b/yeelight_light_ceiling10.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling11.yaml
+++ b/yeelight_light_ceiling11.yaml
@@ -27,6 +27,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling15.yaml
+++ b/yeelight_light_ceiling15.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling20.yaml
+++ b/yeelight_light_ceiling20.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling22.yaml
+++ b/yeelight_light_ceiling22.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_ceiling24.yaml
+++ b/yeelight_light_ceiling24.yaml
@@ -26,6 +26,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -31,6 +31,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_lamp9.yaml
+++ b/yeelight_light_lamp9.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeelight_light_strip6.yaml
+++ b/yeelight_light_strip6.yaml
@@ -23,6 +23,7 @@ esp32:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/yeerc_ylyk01yl.yaml
+++ b/yeerc_ylyk01yl.yaml
@@ -28,6 +28,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   fast_connect: true
 
 ota:

--- a/yeerc_ylyk01yl_fancl.yaml
+++ b/yeerc_ylyk01yl_fancl.yaml
@@ -28,6 +28,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   fast_connect: true
 
 ota:


### PR DESCRIPTION
Add `min_auth_mode: WPA2` to all `wifi:` blocks in ESPHome YAML configurations.

This sets the minimum WiFi authentication mode to WPA2 (AES encryption), which:

- Silences the ESPHome deprecation warning that will change defaults in 2026.6.0
- Ensures WPA2 is used instead of WPA (TKIP), which is more secure

Without this setting, ESPHome 2026.6.0 will emit a deprecation warning and future versions may change the default behavior.