### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -442,7 +442,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nylyk01yl_mac_address: AA:BB:CC:DD:EE:FF\nxiaomi_ylyk01yl_mac_address: AA:BB:CC:DD:EE:FF\nylkg07yl_mac_address: AA:BB:CC:DD:EE:FF" > secrets.yaml
           for YAML in yee*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -450,7 +450,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nylkg07yl_mac_address: AA:BB:CC:DD:EE:FF" > tests/secrets.yaml
           for YAML in tests/*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -493,7 +493,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nylyk01yl_mac_address: AA:BB:CC:DD:EE:FF\nxiaomi_ylyk01yl_mac_address: AA:BB:CC:DD:EE:FF\nylkg07yl_mac_address: AA:BB:CC:DD:EE:FF" > secrets.yaml
           # Compile only a few examples as they are all very similar
           for YAML in yeelight_light_lamp9.yaml yeerc_ylyk01yl.yaml; do
             esphome -s external_components_source components compile $YAML
@@ -504,7 +504,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nylkg07yl_mac_address: AA:BB:CC:DD:EE:FF" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/validate-sdkconfig-options.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ ESPHome custom firmware for ESP32 based Yeelight Ceiling Lights.
 * [ESPHome 2024.10.0 or higher](https://github.com/esphome/esphome/releases).
 * TTL-to-USB module (FTDI/CH430/PL2303) and some wires to flash the device once
 
+## Secrets
+
+Create a `secrets.yaml` file with the following keys. Add only the keys that apply to the
+configuration(s) you use:
+
+```yaml
+wifi_ssid: YOUR_WIFI_SSID
+wifi_password: YOUR_WIFI_PASSWORD
+
+# BLE MAC address of the YLYK01YL remote control (yeerc_ylyk01yl.yaml, yeerc_ylyk01yl_fancl.yaml,
+# yeelight_light_fancl5.yaml)
+ylyk01yl_mac_address: AA:BB:CC:DD:EE:FF
+
+# BLE MAC address of the YLYK01YL remote control (yeelight_light_ceila.yaml)
+xiaomi_ylyk01yl_mac_address: AA:BB:CC:DD:EE:FF
+
+# BLE MAC address of the YLKG07YL dimmer (yeedimmer_ylkg07yl.yaml)
+ylkg07yl_mac_address: AA:BB:CC:DD:EE:FF
+```
+
 ## Supported devices
 
 | Name                                             | Model                     | Model no.   | Specs                                   |

--- a/tests/yeedimmer_ylkg07yl-v3-frame-decryption.yaml
+++ b/tests/yeedimmer_ylkg07yl-v3-frame-decryption.yaml
@@ -2,7 +2,7 @@
 
 xiaomi_ylkg07yl:
   id: dimmer
-  mac_address: "F8:24:41:C4:7B:BC"
+  mac_address: !secret ylkg07yl_mac_address
   bindkey: "ef3afd53f5c7853a080a3d52"
   keycode:
     name: "test keycode"

--- a/tests/yeedimmer_ylkg07yl-v4-frame-decryption.yaml
+++ b/tests/yeedimmer_ylkg07yl-v4-frame-decryption.yaml
@@ -2,7 +2,7 @@
 
 xiaomi_ylkg07yl:
   id: dimmer
-  mac_address: "70:C9:12:50:D3:5C"
+  mac_address: !secret ylkg07yl_mac_address
   bindkey: "5ab9badac3b1becfc5ef5dcd"
   keycode:
     name: "test keycode"

--- a/yeedimmer_ylkg07yl.yaml
+++ b/yeedimmer_ylkg07yl.yaml
@@ -38,7 +38,7 @@ esp32_ble_tracker:
     active: false
 
 xiaomi_ylkg07yl:
-  mac_address: "F8:24:41:C4:7B:BC"
+  mac_address: !secret ylkg07yl_mac_address
   bindkey: "ef3afd53f5c7853a080a3d52"
   keycode:
     name: "last keycode"

--- a/yeelight_light_ceila.yaml
+++ b/yeelight_light_ceila.yaml
@@ -4,8 +4,6 @@ substitutions:
   cold_max_power: "0.7"
   cwww_gamma_correction: "1.6"
   nl_gamma_correction: "1.6"
-  # Xiaomi YLYK01YL remote control settings - you must provide your own MAC address
-  xiaomi_ylyk01yl_mac_address: "00:00:00:00:00:00"
   adjust_brightness_step: "0.1"
   adjust_brightness_min: "0.1"
   adjust_brightness_max: "1.0"
@@ -178,7 +176,7 @@ esp32_ble_tracker:
 
 xiaomi_ble:
 xiaomi_ylyk01yl:
-  mac_address: "${xiaomi_ylyk01yl_mac_address}"
+  mac_address: !secret xiaomi_ylyk01yl_mac_address
   on_press:
     - keycode: 0  # on
       then:

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -108,8 +108,7 @@ esp32_ble_tracker:
     active: false
 
 xiaomi_ylyk01yl:
-  # change mac_address here
-  mac_address: "A4:C1:38:6E:85:0B"
+  mac_address: !secret ylyk01yl_mac_address
   last_button_pressed:
     name: "last button pressed"
 

--- a/yeerc_ylyk01yl.yaml
+++ b/yeerc_ylyk01yl.yaml
@@ -48,7 +48,7 @@ esp32_ble_tracker:
     active: false
 
 xiaomi_ylyk01yl:
-  mac_address: "A4:C1:38:6C:23:2D"
+  mac_address: !secret ylyk01yl_mac_address
   last_button_pressed:
     name: "last button pressed"
 

--- a/yeerc_ylyk01yl_fancl.yaml
+++ b/yeerc_ylyk01yl_fancl.yaml
@@ -48,7 +48,7 @@ esp32_ble_tracker:
     active: false
 
 xiaomi_ylyk01yl:
-  mac_address: "A4:C1:38:6C:23:2D"
+  mac_address: !secret ylyk01yl_mac_address
   last_button_pressed:
     name: "last button pressed"
 


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret` directly in `ble_client:` instead of using hard-coded YAML substitutions
- Update CI to generate the required secret keys (`ylyk01yl_mac_address`, `xiaomi_ylyk01yl_mac_address`, `ylkg07yl_mac_address`) with example values
- Document the new secrets in the README installation section