### PR TITLE
Add Staria Bedside Lamp Pro (YLCT03YL) config, hardware notes, and network flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ ESPHome custom firmware for ESP32 based Yeelight Ceiling Lights.
 | Yeelight Ceiling Light 400C                      | yeelight.light.ceilb      | YLXDD-0034  | AC220V, 24W, 2000lm, 2700K-6500K, RGB ambient light |
 | Yeelight Jiaoyue 260 Ceiling Light               | yeelight.light.ceiling24  | YLXD62YI    | AC220V, 10W, 670LM, 2700K-6500K, 26cm |
 
+### Flashing without opening the device
+
+Every procedure in this repository flashes over UART. On ESP32 models running
+stock firmware there is a network-only route: the device's own `miIO.ota`
+mechanism, relayed through the Xiaomi cloud, pointed at a file on your LAN.
+See [docs/flashing-over-the-network.md](docs/flashing-over-the-network.md) and
+the helpers in [`tools/`](tools).
+
+Confirmed on `yeelink.light.lamp9` firmware 2.1.7_0031. It writes only the
+application partition, so it cannot rescue a device that will not boot - that
+still needs UART.
+
 ### More ESPHome + Yeelight projects
 
 - [Yeelight LED Screen Light Bar (YLTD001)](https://github.com/dckiller51/esphome-yeelight-led-screen-light-bar)
@@ -108,6 +120,12 @@ ESPHome custom firmware for ESP32 based Yeelight Ceiling Lights.
   - Color temperature (2700K-6500K)
 - Nightlight (2700K)
   - Brightness
+
+The Staria **Pro** (YLCT03YL) additionally has a Qi charger and its status LED.
+See [`yeelight_light_lamp9_pro.yaml`](yeelight_light_lamp9_pro.yaml) and
+[the hardware notes](docs/yeelink-light-lamp9-staria-pro.md): the white channels
+need a PWM floor to dim without dropping out, and GPIO33 only *enables* the
+status LED rather than driving it.
 
 ### yeelink.light.strip6
 
@@ -330,9 +348,17 @@ The ESP32 will enter the serial bootloader when GPIO0 (test point IO0 at the bac
 | GPIO0               | TP next to C37  | GPIO0        |                       |
 | SCL (I2C)           |                 | GPIO18       |                       |
 | SDA (I2C)           |                 | GPIO17       |                       |
-| LED (YLCT03YL only) |                 | GPIO33       |                       |
+| LED enable (YLCT03YL) |               | GPIO33       | see note below        |
 | 3.3V                | +, TP7          | 3.3V         |                       |
 | GND                 | -, TP8          | GND          |                       |
+
+On the Pro (YLCT03YL), GPIO33 does not drive the charger status LED - it enables
+the LED's supply rail through a transistor. The Qi charger drives the other half
+of the circuit and decides the pattern itself, so **both** must be active for
+the LED to light. Toggling GPIO33 with no phone on the charger does
+nothing, which is easily mistaken for a dead LED or a wrong pin. The ESP32 has no
+path to read charge state. Details in
+[docs/yeelink-light-lamp9-staria-pro.md](docs/yeelink-light-lamp9-staria-pro.md).
 
 ### yeelink.light.ceiling24
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -159,10 +159,13 @@ work an SSID picked up a trailing `\r` from a CRLF file, the lamp came up on
 ESPHome unable to join, and the fallback AP turned a teardown into a two-minute
 captive-portal fix.
 
-Worth knowing: credentials entered through the captive portal are stored in NVS
-and **replace** the compiled-in ones (`set_sta`, not `add_sta`). They survive
-subsequent OTA updates, so a device can keep working on portal-saved credentials
-even while the firmware carries a wrong SSID.
+Worth knowing how portal-saved credentials behave, because it is easy to get
+wrong. They are stored in NVS and **replace** the compiled-in ones (`set_sta`, not
+`add_sta`) - so a device can keep running on them while the firmware carries a
+wrong SSID. But the preference is keyed on `App.get_config_version_hash()`, so
+**any configuration change orphans them** and the device falls back to whatever is
+compiled in. They persist across a plain re-flash of the same config, not across
+an edited one.
 
 ## What is safe and what is not
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -1,0 +1,185 @@
+# Flashing over the network, without opening the device
+
+Every documented conversion in this project flashes over UART, which means taking
+the device apart. On ESP32 Yeelights running stock firmware there is another
+route: the device's own `miIO.ota` update mechanism can be pointed at a file on
+your LAN.
+
+Confirmed here on `yeelink.light.lamp9` firmware `2.1.7_0031`
+(`miio_ver 0.0.9`). Third parties report the same mechanism working on
+`yeelink.light.ceiling22`; that was not verified as part of this work.
+
+> **Read the limits first.** This writes only the application partition. The
+> stock bootloader and partition table remain, so it cannot recover a device that
+> will not boot - that still needs UART. Take a flash backup over UART first if
+> you want any way back, because no stock firmware image for these models is
+> archived anywhere public.
+
+---
+
+## Why the obvious approach fails
+
+Sending `miIO.ota` **locally** over UDP 54321 with a valid token is refused:
+
+```
+{"code": -30020, "message": "service not available."}
+```
+
+The response is identical with no parameters at all and with a full payload,
+which places the refusal above the parameter layer: five payload shapes were
+tried and none made any difference. Local OTA is disabled on this firmware, and
+the update command has to arrive from the Xiaomi cloud instead.
+
+Useful error signatures when probing:
+
+| Response | Meaning |
+| -------- | ------- |
+| `-9999 user ack timeout` | method not implemented; firmware never acknowledges |
+| `-32602 Invalid param.` | method exists, parameter validation rejected the input |
+| `-30020 service not available.` | method exists, the service refuses before parsing |
+
+## The route that works
+
+Xiaomi's cloud exposes an RPC relay that forwards a raw miIO call to a device you
+own. Because the command then originates from the server, the OTA service accepts
+it - and `app_url` may point anywhere the device can reach, including a private
+LAN address over plain HTTP.
+
+```
+POST https://<region>.api.io.mi.com/app/home/rpc/<did>
+data = {"id":N,"method":"miIO.ota","params":{"app_url":"http://<your-lan-ip>:8000/fw_crc.bin"}}
+```
+
+Two things about that payload matter:
+
+- `app_url` alone is what worked here (`mcu_url` is the equivalent for the
+  companion MCU). The larger payload shown in `python-miio` - `mode`, `install`,
+  `file_md5`, `proc` - was not tested over the cloud channel, so this is what is
+  known to work rather than the only form that does.
+- No checksum is passed in this form, so nothing in the protocol protects you
+  from shipping a bad image.
+
+The cloud only relays the instruction. The firmware file never leaves your LAN.
+
+## Two requirements that are easy to miss
+
+### 1. The image carries a 4-byte CRC trailer
+
+Xiaomi's own ESP32 update images are a normal ESP-IDF application image - whose
+internal SHA-256 verifies - followed by four extra bytes. A plain ESPHome
+`firmware.bin` has no trailer, so one was appended here to match the vendor
+format. Whether the device rejects an image without it was not tested.
+
+The algorithm is **not** a standard CRC-32; none of the catalogued variants
+reproduce it:
+
+```
+CRC-32, polynomial 0x04C11DB7 (reflected 0xEDB88320)
+        init 0x00000000, refin/refout = true, xorout 0x00000000
+        stored little-endian
+```
+
+That is standard CRC-32 without the customary pre- and post-inversion. Verified
+against two unrelated Xiaomi images - one ESP32, one MT7697 - which both
+reproduce exactly.
+
+`tools/append_crc.py` implements it, and can verify itself against any genuine
+Xiaomi image you have.
+
+### 2. The HTTP server must speak HTTP/1.1
+
+The device's downloader identifies itself as `User-Agent: MIoT`. Against an
+HTTP/1.0 server it connects, begins reading, then resets the connection - three
+times in quick succession - and returns to `idle` with nothing written:
+
+```
+"GET /fw_crc.bin HTTP/1.1" 200 -
+ConnectionResetError: [Errno 104] Connection reset by peer   (x3)
+```
+
+Python's `http.server` answers HTTP/1.0 and ignores `Range`, so it fails here.
+Serving byte-identical content over HTTP/1.1 with keep-alive and range support
+works first time. `tools/ota_server.py` is a minimal server that does this and
+logs what the device actually requests.
+
+## Procedure
+
+1. **Recover the device token and `did`** from the Xiaomi cloud. Existing tools
+   cover this; note the Yeelight app account and the Xiaomi account may be the
+   same identity, in which case no re-pairing is needed.
+
+2. **Build the ESPHome image** for your model. Include `ap:` and
+   `captive_portal:` - see the warning below.
+
+3. **Check it fits.** Only the application partition is written and the stock
+   partition table stays, so the image must fit the slot the stock firmware uses.
+   The stock partition table has not been dumped, so the exact slot size is
+   unknown. The `lamp9` ESPHome build used here was 810 KB and installed without
+   trouble.
+
+4. **Append the CRC trailer:**
+
+   ```
+   python3 tools/append_crc.py firmware.bin fw_crc.bin
+   ```
+
+5. **Serve it over HTTP/1.1** and confirm another host on the LAN can fetch the
+   whole file before going further:
+
+   ```
+   python3 tools/ota_server.py fw_crc.bin 8000
+   ```
+
+6. **Relay the OTA command through the cloud:**
+
+   ```
+   python3 tools/cloud_ota.py --server de --ip <device-ip> \
+       --url http://<your-lan-ip>:8000/fw_crc.bin
+   ```
+
+7. **Watch it land.** `miIO.get_ota_state` walks `idle -> downloading ->
+   installed`, the server logs one full-size `GET`, and the device reboots into
+   ESPHome. The stock protocols (TCP 55443, UDP 54321) go silent.
+
+## Always include a fallback AP
+
+```yaml
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "fallback-ap"
+
+captive_portal:
+```
+
+A wrong credential is otherwise unrecoverable without UART - which defeats the
+entire point of flashing over the network. This is not hypothetical: during this
+work an SSID picked up a trailing `\r` from a CRLF file, the lamp came up on
+ESPHome unable to join, and the fallback AP turned a teardown into a two-minute
+captive-portal fix.
+
+Worth knowing: credentials entered through the captive portal are stored in NVS
+and **replace** the compiled-in ones (`set_sta`, not `add_sta`). They survive
+subsequent OTA updates, so a device can keep working on portal-saved credentials
+even while the firmware carries a wrong SSID.
+
+## What is safe and what is not
+
+Confirmed non-destructive on the reference unit:
+
+- An OTA pointed at a URL returning **404** - the device fetches, fails, returns
+  to `idle`, unharmed. A useful way to prove the path end to end without
+  installing anything.
+- Aborted transfers, including the HTTP/1.0 resets above.
+- Unknown or malformed miIO methods, which are ignored without a reboot.
+
+Not verified, and where the real risk lies:
+
+- The **install** stage. Once a valid image downloads it is written and booted.
+  A third-party report describes an official Yeelight OTA bricking a ceiling
+  light, so this firmware's install path can write something unbootable.
+- The OTA call itself carries no checksum, so nothing at the protocol level
+  distinguishes a correct image from one built for the wrong model. What the
+  firmware checks beyond the CRC trailer, and how it behaves on a bad image, was
+  not tested - deliberately.

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -13,7 +13,7 @@ which board is inside.
 
 ## Status LED is an AND gate across two boards
 
-The base `yeelink.light.lamp9` config lists GPIO33 as `LED (YLCT03YL only)` and
+`yeelight_light_lamp9.yaml` lists GPIO33 as `LED (YLCT03YL only)` and
 drives it as a plain output. That is correct as far as it goes, but it will not
 light the LED on its own, and the reason is not obvious from software.
 
@@ -138,6 +138,13 @@ usable output is around 6%. Mid-range both channels run, so it is roughly 12%
 combined. The night light uses a different driver, dims cleanly below 1%, and is
 the right output for very low light.
 
+The configured `min_duty` is the value at which output was verified steady, and
+there is still a little room below it before the driver actually gives up - so
+the floor is not set knife-edge on this unit's exact threshold. A unit whose
+driver conducts slightly differently should therefore still be fine; a unit that
+needs a *higher* floor would show flicker at the bottom of the range, which is a
+cosmetic fault rather than a damaging one, and is fixed by raising `min_duty`.
+
 Measuring the floor on your own unit: drive `pwm_warm` and `pwm_cold` directly
 with `output.set_level` and raise the value until the LED lights without flicker.
 Note that `output.set_level` on a wrapped output goes through the same mapping as
@@ -188,19 +195,94 @@ ESPHome normalises the two channel fractions so `max(cw, ww) == 1`, then
 
 With `constant_brightness: true` the sum is held constant across the whole
 range, so both channels can never run at full and the lamp tops out at one
-channel's worth of light. This config uses **false**, which makes the mired
-midpoint the maximum-output point - both channels at 100% - matching the stock
-firmware. The cost is that brightness varies as colour temperature moves, which
-the stock lamp also does.
+channel's worth of light.
+
+This config uses **true**, and that is a measured choice. Two lamps were compared
+side by side, one left on stock firmware and one converted, with a phone lux
+meter held against the diffuser:
+
+| Condition | stock | `constant_brightness: false` |
+| --------- | ----- | ---------------------------- |
+| 100% @ 2700K | 14,500 | 14,500 |
+| 100% @ 6500K | 14,400 | 14,600 |
+| 100% @ 3815K | **16,000** | **28,000** |
+
+The two lamps agree within 1% at either extreme, where the setting has no effect
+because only one channel runs, so the midpoint difference is the setting and not
+the hardware. Stock rises only **1.11x** from the extremes to the midpoint - it
+holds output roughly constant. With `false` the converted lamp reached **1.92x**,
+so **1.75x brighter than stock ever drives it**, with both LED sets at full duty
+on a shared heatsink. Optical output nearly doubling means input power and
+therefore heat roughly double as well.
+
+With `true` the converted lamp matches stock at all three points.
+
+An earlier version of these notes claimed `false` matched the stock firmware.
+That was reasoning from how the component works, not measurement, and it was
+wrong.
 
 That midpoint is 3815K, and it is worth knowing where it appears in Home
 Assistant: mireds are reciprocal to Kelvin, and the HA slider is linear in
 Kelvin, so the mired midpoint sits at about **29%** of a 2700-6500K slider
 rather than halfway along it.
 
-`constant_brightness: true` is also what made the low-brightness dropout worse:
-splitting the requested brightness across both channels at mid colour
-temperature put each one under the driver's conduction floor.
+### What `true` costs at the bottom of the range
+
+Splitting the requested brightness across both channels at mid colour temperature
+sends each one closer to the driver's conduction floor, which is what the deadband
+and `min_duty` mapping on the outputs exist to handle. Measured at 1% brightness:
+
+| Condition | stock | this config (`true`) |
+| --------- | ----- | -------------------- |
+| 1% @ 2700K | 1,200 | 480 |
+| 1% @ 6500K | 1,100 | 500 |
+| 1% @ 3815K | 1,600 | 820 |
+
+Two things fall out of that.
+
+The lamp gets **brighter** toward mid colour temperature at low brightness -
+1.67x the extremes here - because `min_duty` is a floor applied *per channel*, so
+lighting both doubles it. Stock does the same thing, 1.39x, so the shape is not an
+artefact of this config; it is milder on stock because its floor is lower.
+
+At the same slider position this config sits at roughly **0.4-0.5x** stock's
+output, and that is about the brightness *curve* rather than about
+`constant_brightness`.
+
+Measured at 1%, stock delivers about **8%** of its full output while this config
+delivers about **3.3%**. That is the extent of what was measured - two brightness
+settings, 1% and 100%, so the shape of stock's curve between them is unknown and
+no exponent is claimed for it.
+
+On this side the chain is known: both this config and `yeelight_light_lamp9.yaml` set
+`gamma_correct: 0`, which in ESPHome means gamma correction is **disabled** -
+`gamma <= 0` returns the value unchanged - so a 1% request stays 1%, is lifted by
+the `${min_duty}` floor to about 6.9% duty, and the driver turns that into roughly
+3.3% of full light. Note that last step: the driver's own duty-to-light response
+is non-linear, so lux readings measure the slider, the curve and the driver
+together, not the curve alone.
+
+The practical effect is that this config reaches a *dimmer* minimum than stock
+can, which suits a bedside lamp, at the cost of the slider feeling less like the
+original at low settings.
+
+`gamma_correct` is the knob for this, and its direction is worth stating because
+it is easy to get backwards. ESPHome applies `output = request ^ gamma`, so
+*raising* it makes the bottom of the range dimmer, not brighter: at the 2.8
+default a 1% request becomes 0.0003% duty, far below this driver's conduction
+floor, and the whole bottom of the slider is dead. That is why it is disabled
+here - it keeps the mapping predictable enough for the `${min_duty}` floor and
+deadband to work. A value below 1 would push more output into the low end.
+
+Matching stock's low-end feel would need its curve measured properly first: a
+brightness sweep at fixed colour temperature on a stock unit, enough points to see
+whether it is even a power law or a lookup table with a knee. Two points cannot
+tell those apart.
+
+One edge worth knowing: at mid colour temperature each channel receives half the
+requested brightness, so below about **0.8%** both fall under the `${deadband}`
+and the lamp goes fully dark. Home Assistant's slider bottoms out at 1%, so this
+is only reachable from a scene or automation setting a fractional value.
 
 ## How the device is identified in Home Assistant
 

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -174,3 +174,30 @@ not using.
 Home Assistant can also override the fade per call with the `transition`
 parameter of `light.turn_on` / `light.turn_off`, which takes precedence over the
 default.
+
+## Brightness across colour temperature
+
+ESPHome normalises the two channel fractions so `max(cw, ww) == 1`, then
+`constant_brightness` decides how they are combined. At 100% brightness:
+
+| Colour temp | `constant_brightness: true` | `constant_brightness: false` |
+| ----------- | --------------------------- | ---------------------------- |
+| 2700K warm  | one channel 100%, sum 100%  | one channel 100%, sum 100%   |
+| 3815K       | each 50%, sum 100%          | **both 100%, sum 200%**      |
+| 6500K cold  | one channel 100%, sum 100%  | one channel 100%, sum 100%   |
+
+With `constant_brightness: true` the sum is held constant across the whole
+range, so both channels can never run at full and the lamp tops out at one
+channel's worth of light. This config uses **false**, which makes the mired
+midpoint the maximum-output point - both channels at 100% - matching the stock
+firmware. The cost is that brightness varies as colour temperature moves, which
+the stock lamp also does.
+
+That midpoint is 3815K, and it is worth knowing where it appears in Home
+Assistant: mireds are reciprocal to Kelvin, and the HA slider is linear in
+Kelvin, so the mired midpoint sits at about **29%** of a 2700-6500K slider
+rather than halfway along it.
+
+`constant_brightness: true` is also what made the low-brightness dropout worse:
+splitting the requested brightness across both channels at mid colour
+temperature put each one under the driver's conduction floor.

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -1,0 +1,163 @@
+# Yeelight Staria Bedside Lamp Pro (YLCT03YL, `yeelink.light.lamp9`)
+
+Hardware notes for the Pro variant, gathered by probing and tracing one unit.
+
+**Reference unit:** production date 2020-10, module ESP32-WROOM-32D,
+stock firmware `2.1.7_0031`, `miio_ver 0.0.9`.
+
+Only this one unit was examined. The Pro and the non-Pro Staria both report the
+internal model `yeelink.light.lamp9`, so the model string alone does not tell you
+which board is inside.
+
+---
+
+## Status LED is an AND gate across two boards
+
+The base `yeelink.light.lamp9` config lists GPIO33 as `LED (YLCT03YL only)` and
+drives it as a plain output. That is correct as far as it goes, but it will not
+light the LED on its own, and the reason is not obvious from software.
+
+The Pro has two boards - the ESP board and the Qi charger board - joined by
+exactly three wires: **GND**, **+12V**, and one signal pad labelled **`GPIO-WL`**
+on the ESP board. The status LED itself sits on the ESP board.
+
+```
+   V+ ──┬─────────────────── emitter ──┐
+        │                              │
+       R43                          [R1A]   PNP, high side
+        │                              │
+        └──── base ◄── R44 ◄── R? ◄── collector ── [6C] NPN #2
+                                                        │
+              ESP32 GPIO33 ── R16 (4.7k) ──────► base ──┤
+                                                        │
+                                                    emitter ──► GND
+                              │
+                         collector (pin 3)
+                              │
+                            R42 (2k)
+                              │
+                            LED1
+                              │
+                         collector ── [6C] NPN #1
+                                          │
+  charger LED out ──► GPIO-WL ──► R40 ──┬─► base
+                                        │     │
+                                     R41 (8.2k)│
+                                        │  emitter ──► GND
+                                       GND
+                                        │
+                                       C37
+```
+
+Both three-pin parts are SOT-23. `6C` matches the marking code for a BC817 NPN.
+The part marked `R1A` was not identified; its role as a high-side switch is
+inferred from where its legs go, not from the marking. The component between
+NPN #2 and R44 reads above 20k and was not identified either.
+
+**Both halves must conduct for the LED to light:**
+
+| Half | Driven by | Role |
+| ---- | --------- | ---- |
+| High side (`R1A` via NPN #2, from GPIO33) | **ESP32** | enables the LED supply rail |
+| Low side (NPN #1, from `GPIO-WL`) | **Qi charger** | drives the indication pattern |
+
+So GPIO33 is an **enable**, not a drive. The charger decides the pattern by
+itself; the ESP32 only permits or suppresses it. Observed behaviour:
+
+| Charger state | LED |
+| ------------- | --- |
+| phone charging | steady on |
+| phone present but not aligned | blinking |
+| no phone | off |
+
+This is easy to misdiagnose. Toggling the GPIO33 light entity with no phone on
+the charger does nothing at all, which looks exactly like a dead LED or a wrong
+pin. Verify with a phone charging **and** the enable on.
+
+### Practical consequence
+
+You can suppress the charge indicator (useful at night) by turning the enable
+off. You cannot make the LED light on demand, and you cannot change its pattern.
+
+## The ESP32 cannot see charge state
+
+There is no path from the charger to any ESP32 pin. The charger's only signal
+(`GPIO-WL`) terminates at the base of NPN #1; that node connects to nothing else
+on the board. Verified by continuity against every WROOM castellation.
+
+Also checked and found empty:
+
+- every free GPIO sampled with deterministic pull-ups, while a phone was placed,
+  moved off-centre and removed - no pin changed state
+- both plausible I2C buses. GPIO17/18 has one device at `0x10`, whose full 256
+  register space reads `0x00` and never changes. GPIO21/22 is empty
+
+Charge state therefore cannot be exposed to Home Assistant without modifying the
+hardware. GPIO13, GPIO15, GPIO16, GPIO19 and GPIO23 were found unused on this
+board, but no modification was attempted or tested.
+
+## White channels will not dim below ~6% duty
+
+The constant-current driver stops conducting reliably under roughly **6% PWM
+duty** on this unit. Measured by driving the raw LEDC channels directly and
+raising the duty until the LEDs lit steadily.
+
+Symptoms when this is not compensated for:
+
+- at or below ~4% brightness the light goes fully dark
+- at ~5% it lights only near the colour temperature extremes; moving toward the
+  middle makes it flicker and then drop out
+
+The second symptom is the giveaway. With `constant_brightness`, mid-range colour
+temperature splits the requested brightness across both channels, so each one
+falls under the threshold even though their sum does not.
+
+### Why `min_power` alone is not the fix
+
+`min_power` lifts *every* non-zero value, and `zero_means_zero` only catches an
+exact `0.0`. The light component does not produce an exact zero at the colour
+temperature extremes: with the range declared as 2700K-6500K, a request for the
+warm end arrives rounded in mireds and leaves the cold channel at about **0.17%**
+rather than 0.
+
+```
+ct_ratio = (370 - 153.846) / (370.370 - 153.846) = 0.99829
+  -> warm 99.83%, cold 0.171%
+```
+
+`min_power` raises that residual to the full 6% floor, and since the cold LEDs
+are brighter per unit duty, "maximum warm" comes out visibly cold.
+
+The config uses template outputs with a **deadband** instead: below `deadband`
+the channel is genuinely off, at or above it the floor applies.
+
+### Range floor
+
+At the colour temperature extremes one channel carries everything, so the dimmest
+usable output is around 6%. Mid-range both channels run, so it is roughly 12%
+combined. The night light uses a different driver, dims cleanly below 1%, and is
+the right output for very low light.
+
+Measuring the floor on your own unit: drive `pwm_warm` and `pwm_cold` directly
+with `output.set_level` and raise the value until the LED lights without flicker.
+Note that `output.set_level` on a wrapped output goes through the same mapping as
+the light, so measure against the raw `ledc` outputs, not the template ones.
+
+## PWM frequency
+
+ESPHome's LEDC default of 1 kHz at 16-bit resolution is not the limiting factor -
+6% duty is thousands of steps in, nowhere near quantisation. The floor is the LED
+driver's conduction threshold. No other frequency was tested.
+
+## Bootloader note when flashing over the network
+
+Flashing over the air replaces only the application partition; the stock
+bootloader and partition table stay in place. ESPHome reports:
+
+```
+[W][app:190]: Bootloader too old for OTA rollback and SRAM1 as IRAM (+40KB).
+[C][safe_mode:079]:   Bootloader rollback: not supported
+```
+
+Harmless in practice, but it costs around 40KB of IRAM and there is no OTA
+rollback protection. Only a UART flash replaces the bootloader.

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -201,3 +201,22 @@ rather than halfway along it.
 `constant_brightness: true` is also what made the low-brightness dropout worse:
 splitting the requested brightness across both channels at mid colour
 temperature put each one under the driver's conduction floor.
+
+## How the device is identified in Home Assistant
+
+Without help, Home Assistant labels the device *esp32doit-devkit-v1 by Espressif*.
+The API reports `ESPHOME_BOARD` as the model and a hardcoded per-platform string
+as the manufacturer, and neither is configurable.
+
+Home Assistant does, however, split `project.name` on its single dot and use the
+halves, so the config sets:
+
+```yaml
+esphome:
+  project:
+    name: "Yeelight.Staria Bedside Lamp Pro"
+    version: "1.0"
+```
+
+which yields `manufacturer=Yeelight`, `model=Staria Bedside Lamp Pro`, and a
+`sw_version` of `1.0 (ESPHome <version>)`.

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -161,3 +161,16 @@ bootloader and partition table stay in place. ESPHome reports:
 
 Harmless in practice, but it costs around 40KB of IRAM and there is no OTA
 rollback protection. Only a UART flash replaces the bootloader.
+
+## Transition length
+
+`default_transition_length` is a compile-time setting in ESPHome, so the config
+also exposes a `transition length` number entity that calls
+`set_default_transition_length()` on both lights at runtime. The value is stored
+on the device and reapplied on boot - restoring a template number does not re-run
+its `set_action`, so without that the entity would show a value the lights were
+not using.
+
+Home Assistant can also override the fade per call with the `transition`
+parameter of `light.turn_on` / `light.turn_off`, which takes precedence over the
+default.

--- a/tools/append_crc.py
+++ b/tools/append_crc.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Append Xiaomi's 4-byte OTA trailer to an ESP-IDF application image.
+
+Xiaomi's ESP32 firmware images are a normal ESP-IDF application image followed by
+four extra bytes. An ESPHome build has no trailer, and the stock updater will not
+accept it without one.
+
+The algorithm was recovered by matching against genuine Xiaomi images. It is not
+a standard CRC-32 - none of the catalogued variants reproduce it:
+
+    CRC-32, polynomial 0x04C11DB7 (reflected 0xEDB88320)
+            init 0x00000000, refin/refout = true, xorout 0x00000000
+            stored little-endian
+
+i.e. standard CRC-32 without the customary pre- and post-inversion. Verified
+against an ESP32 image and an MT7697 image from different Xiaomi product lines;
+both reproduce exactly.
+
+Usage:
+    append_crc.py <in.bin> <out.bin>       append the trailer
+    append_crc.py --verify <image.bin>     check a genuine Xiaomi image
+"""
+
+import struct
+import sys
+
+_TABLE = []
+for _i in range(256):
+    _c = _i
+    for _ in range(8):
+        _c = (_c >> 1) ^ (0xEDB88320 if _c & 1 else 0)
+    _TABLE.append(_c)
+
+
+def xiaomi_crc(buf: bytes) -> int:
+    """CRC-32 with a zero init and no final inversion."""
+    crc = 0
+    for b in buf:
+        crc = (crc >> 8) ^ _TABLE[(crc ^ b) & 0xFF]
+    return crc & 0xFFFFFFFF
+
+
+def verify(path: str) -> int:
+    with open(path, "rb") as f:
+        data = f.read()
+    body, trailer = data[:-4], data[-4:]
+    packed = struct.pack("<I", xiaomi_crc(body))
+    print(f"stored trailer : {trailer.hex()}")
+    print(f"computed (LE)  : {packed.hex()}")
+    ok = packed == trailer
+    print("VERIFIED" if ok else "MISMATCH")
+    return 0 if ok else 1
+
+
+def append(src: str, dst: str) -> int:
+    with open(src, "rb") as f:
+        body = f.read()
+    if body[:1] != b"\xe9":
+        print(f"warning: {src} does not start with 0xE9 and may not be an "
+              f"ESP-IDF application image", file=sys.stderr)
+    crc = xiaomi_crc(body)
+    out = body + struct.pack("<I", crc)
+    with open(dst, "wb") as f:
+        f.write(out)
+    print(f"in   : {src}  {len(body)} bytes")
+    print(f"crc  : {crc:08x}  -> trailer {struct.pack('<I', crc).hex()}")
+    print(f"out  : {dst}  {len(out)} bytes")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) == 3 and sys.argv[1] == "--verify":
+        return verify(sys.argv[2])
+    if len(sys.argv) == 3:
+        return append(sys.argv[1], sys.argv[2])
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cloud_ota.py
+++ b/tools/cloud_ota.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Relay a miIO OTA command to a Yeelight through the Xiaomi cloud.
+
+Current stock firmware refuses `miIO.ota` sent directly over the LAN:
+
+    {"code": -30020, "message": "service not available."}
+
+The same command is accepted when it arrives from the Xiaomi cloud, and the
+`app_url` may point at a private LAN address over plain HTTP. The cloud only
+relays the instruction - the firmware file never leaves your network.
+
+    POST https://<region>.api.io.mi.com/app/home/rpc/<did>
+    data = {"id":N,"method":"miIO.ota","params":{"app_url":"http://..."}}
+
+Note the parameter shape: `app_url` alone (or `mcu_url` for the companion MCU).
+That is the form confirmed to work; the larger payload documented by python-miio
+was not tested over this channel. No checksum is passed in this form.
+
+Authentication is handled by Xiaomi-cloud-tokens-extractor, which deals with the
+captcha and email 2FA that Xiaomi's login now requires:
+
+    https://github.com/PiotrMachowski/Xiaomi-cloud-tokens-extractor
+
+Point --extractor at a checkout of it. Credentials are read from the environment
+so they never appear in a command line or shell history:
+
+    export MI_USERNAME=...
+    export MI_PASSWORD=...
+
+Usage:
+    cloud_ota.py --ip 192.0.2.10 --url http://192.0.2.2:8000/fw_crc.bin
+    cloud_ota.py --ip 192.0.2.10 --state          # just read OTA state
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+
+def load_connector(extractor_path: str):
+    sys.path.insert(0, extractor_path)
+    try:
+        import token_extractor as te  # noqa: PLC0415
+    except ImportError:
+        print(f"could not import token_extractor from {extractor_path}\n"
+              f"clone Xiaomi-cloud-tokens-extractor and pass --extractor",
+              file=sys.stderr)
+        raise SystemExit(2)
+    return te
+
+
+def find_device(connector, server: str, ip: str):
+    homes = []
+    h = connector.get_homes(server)
+    if h:
+        homes.extend({"home_id": x["id"], "home_owner": connector.userId}
+                     for x in h["result"]["homelist"])
+    cnt = connector.get_dev_cnt(server)
+    if cnt:
+        homes.extend({"home_id": x["home_id"], "home_owner": x["home_owner"]}
+                     for x in cnt["result"]["share"]["share_family"])
+
+    for home in homes:
+        devs = connector.get_devices(server, home["home_id"], home["home_owner"])
+        if not devs or not devs.get("result", {}).get("device_info"):
+            continue
+        for d in devs["result"]["device_info"]:
+            if d.get("localip") == ip:
+                return d
+    return None
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--ip", required=True, help="device LAN address, used to identify it")
+    p.add_argument("--url", help="firmware URL to hand the device")
+    p.add_argument("--server", default="de",
+                   help="Xiaomi cloud region: cn, de, us, ru, tw, sg, i2 (default: de)")
+    p.add_argument("--extractor", default="./Xiaomi-cloud-tokens-extractor",
+                   help="path to a Xiaomi-cloud-tokens-extractor checkout")
+    p.add_argument("--state", action="store_true",
+                   help="only read OTA state and exit")
+    p.add_argument("--poll", type=int, default=40,
+                   help="how many 5s polls to run after sending (default: 40)")
+    args = p.parse_args()
+
+    if not args.state and not args.url:
+        p.error("--url is required unless --state is given")
+
+    for var in ("MI_USERNAME", "MI_PASSWORD"):
+        if not os.environ.get(var):
+            print(f"{var} is not set", file=sys.stderr)
+            return 2
+
+    sys.argv = ["token_extractor.py",
+                "-u", os.environ["MI_USERNAME"].strip(),
+                "-p", os.environ["MI_PASSWORD"].strip(),
+                "-l", "CRITICAL"]
+    te = load_connector(args.extractor)
+
+    connector = te.PasswordXiaomiCloudConnector()
+    if not connector.login():
+        print("login failed", file=sys.stderr)
+        return 1
+
+    device = find_device(connector, args.server, args.ip)
+    if not device:
+        print(f"no device with local address {args.ip} on server "
+              f"'{args.server}'", file=sys.stderr)
+        return 1
+
+    did = device["did"]
+    print(f"target: {device.get('name')}  model={device.get('model')}  did={did}")
+
+    url = connector.get_api_url(args.server) + f"/home/rpc/{did}"
+    counter = [0]
+
+    def relay(method, params):
+        counter[0] += 1
+        data = (f'{{"id":{counter[0]},"method":"{method}",'
+                f'"params":{json.dumps(params)}}}')
+        print(f">>> {data}", flush=True)
+        resp = connector.execute_api_call_encrypted(url, {"data": data})
+        print(f"<<< {json.dumps(resp)}\n", flush=True)
+        return resp
+
+    relay("miIO.get_ota_state", [])
+    relay("miIO.get_ota_progress", [])
+    if args.state:
+        return 0
+
+    relay("miIO.ota", {"app_url": args.url})
+
+    # `installed` means the image was written; the device then reboots and stops
+    # answering miIO entirely, which is the real success signal.
+    for i in range(args.poll):
+        time.sleep(5)
+        r = relay("miIO.get_ota_state", [])
+        state = (r or {}).get("result")
+        if state and state[0] in ("installing", "installed"):
+            print(f"[t+{(i + 1) * 5}s] state = {state[0]}", flush=True)
+        if state and state[0] == "failed":
+            print("OTA reported failure", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ota_server.py
+++ b/tools/ota_server.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Serve a firmware image to a Yeelight's stock OTA downloader.
+
+The downloader (User-Agent: MIoT) will not complete a transfer from an HTTP/1.0
+server: it connects, starts reading, then resets the connection, and the device
+returns to `idle` with nothing written. Python's built-in http.server answers
+HTTP/1.0 and ignores Range, so it fails here.
+
+This server speaks HTTP/1.1 with keep-alive, honours Range requests, and logs
+exactly what the device asks for and how many bytes were delivered - which makes
+a failed transfer obvious rather than silent.
+
+Usage:
+    ota_server.py <firmware.bin> [port]
+
+The file is served at any path, so the URL passed to miIO.ota only has to point
+at this host and port.
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import re
+import socketserver
+import sys
+import threading
+
+_lock = threading.Lock()
+
+
+def build_handler(data: bytes):
+    size = len(data)
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        server_version = "nginx/1.24.0"
+        sys_version = ""
+
+        def log_message(self, fmt, *args):
+            pass  # replaced by the explicit logging below
+
+        def _log_request(self):
+            with _lock:
+                print(f"\n=== {self.client_address[0]}:{self.client_address[1]} "
+                      f"{self.command} {self.path} {self.request_version} ===",
+                      flush=True)
+                for k, v in self.headers.items():
+                    print(f"    {k}: {v}", flush=True)
+
+        def do_HEAD(self):
+            self._log_request()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(size))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+
+        def do_GET(self):
+            self._log_request()
+            start, end, partial = 0, size - 1, False
+            rng = self.headers.get("Range")
+            if rng:
+                m = re.match(r"bytes=(\d*)-(\d*)", rng.strip())
+                if m:
+                    if m.group(1):
+                        start = int(m.group(1))
+                    if m.group(2):
+                        end = min(int(m.group(2)), size - 1)
+                    partial = True
+
+            body = data[start:end + 1]
+            self.send_response(206 if partial else 200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Accept-Ranges", "bytes")
+            if partial:
+                self.send_header("Content-Range", f"bytes {start}-{end}/{size}")
+            self.end_headers()
+
+            sent = 0
+            try:
+                while sent < len(body):
+                    n = self.wfile.write(body[sent:sent + 4096])
+                    sent += n or 4096
+                with _lock:
+                    print(f"    --> sent {sent}/{len(body)} bytes  COMPLETE",
+                          flush=True)
+            except Exception as e:  # noqa: BLE001 - report whatever went wrong
+                with _lock:
+                    print(f"    --> sent {sent}/{len(body)} bytes then "
+                          f"DISCONNECT: {type(e).__name__}: {e}", flush=True)
+
+    return Handler
+
+
+class Server(socketserver.ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 8000
+    with open(path, "rb") as f:
+        data = f.read()
+    print(f"serving {path} ({len(data)} bytes) on port {port}", flush=True)
+    print("verify another host on the LAN can fetch the whole file before "
+          "sending the OTA command", flush=True)
+    Server(("0.0.0.0", port), build_handler(data)).serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -18,6 +18,10 @@
 substitutions:
   name: yeelight-light-lamp9-pro
 
+  # Shown in Home Assistant next to the model. Bump when the config changes in a
+  # way worth telling apart on the device page.
+  project_version: "1.0"
+
   # Fade applied when the light turns on or off, in milliseconds. The stock
   # firmware fades over roughly a second. This is the power-on default; it is
   # also adjustable at runtime from the "transition length" number entity, whose
@@ -58,6 +62,14 @@ esphome:
   name: ${name}
   friendly_name: ${name}
   min_version: 2024.10.0
+  # Home Assistant otherwise labels the device "esp32doit-devkit-v1 by Espressif":
+  # the API reports ESPHOME_BOARD as the model and a per-platform hardcoded string
+  # as the manufacturer, neither of which is configurable. HA does however split
+  # project.name on its single dot and use the halves as manufacturer and model,
+  # so setting it here gets the real hardware named instead of the dev board.
+  project:
+    name: "Yeelight.Staria Bedside Lamp Pro"
+    version: "${project_version}"
   on_boot:
     priority: -100
     then:
@@ -83,10 +95,13 @@ wifi:
   # Strongly recommended, especially when flashing over the network: a typo in
   # the credentials otherwise leaves the lamp unreachable and only recoverable
   # over UART, which means opening the device.
-  # Keep the suffix short: an AP SSID cannot exceed 32 characters, and it is
-  # built from ${name}.
+  #
+  # No ssid on purpose. ESPHome then names the AP after the device, including the
+  # MAC suffix if name_add_mac_suffix is set, and truncates to the 32-byte SSID
+  # limit itself. That keeps the rescue AP unique per device without hand-picking
+  # a name, which matters if the device ever changes hands or networks: it falls
+  # back to this AP after ap_timeout (90s by default) whenever it cannot join.
   ap:
-    ssid: "${name}-ap"
 
 captive_portal:
 

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -1,13 +1,15 @@
 # Yeelight Staria Bedside Lamp Pro (YLCT03YL, yeelink.light.lamp9)
 #
 # Variant of yeelight_light_lamp9.yaml for the Pro model, which adds a Qi
-# wireless charger and its status LED. Differences from the base config are
-# documented in docs/yeelink-light-lamp9-staria-pro.md; in short:
+# wireless charger and its status LED. Differences from
+# yeelight_light_lamp9.yaml are documented in
+# docs/yeelink-light-lamp9-staria-pro.md; in short:
 #
-#   * The white channels will not conduct below roughly 6% PWM duty. The base
-#     config drives them straight from the light component, which makes low
-#     brightness drop out entirely and flicker as the colour temperature moves
-#     off the extremes. The template outputs below apply a floor with a deadband.
+#   * The white channels will not conduct below roughly 6% PWM duty.
+#     yeelight_light_lamp9.yaml drives them straight from the light component,
+#     which makes low brightness drop out entirely and flicker as the colour
+#     temperature moves off the extremes. The template outputs below apply a
+#     floor with a deadband.
 #   * GPIO33 is not the status LED drive - it is an ENABLE for the LED's supply
 #     rail. The Qi charger drives the other half of the circuit and decides the
 #     pattern. Both must be active for the LED to light.
@@ -201,13 +203,25 @@ light:
     # Remember brightness and colour temperature across a power cycle but
     # come back off - this is what makes 'restore last state' work.
     restore_mode: RESTORE_AND_OFF
-    # false, not true. With constant_brightness the channel sum is normalised to
-    # a constant, so both channels can never run at full: mid colour temperature
-    # gives 50%/50% instead of 100%/100%, and the lamp tops out at one channel's
-    # worth of output. With it off, the mired midpoint drives both channels at
-    # 100% - twice the light, and what the stock firmware does. Brightness then
-    # varies with colour temperature, which is the stock behaviour too.
-    constant_brightness: false
+    # true, and this is measured rather than reasoned. Two lamps were compared
+    # side by side at 100%, one on stock firmware and one converted, with a lux
+    # meter against the diffuser:
+    #
+    #                       2700 K / 6500 K      3815 K (mired midpoint)
+    #   stock                   ~14,450                16,000   (1.11x)
+    #   constant_brightness off ~14,550                28,000   (1.92x)
+    #
+    # Both lamps agree within 1% at either extreme, where this setting has no
+    # effect, so the midpoint difference is the setting and not the hardware.
+    # Stock rises only 11% across the range - it holds output roughly constant.
+    # With it off the converted lamp ran 1.75x brighter than stock ever drives
+    # it, which means both LED sets at full duty on a shared heatsink.
+    #
+    # The cost of true is at the bottom of the range: mid colour temperature
+    # splits the requested brightness across both channels, so each one reaches
+    # the driver's conduction floor sooner. That is what the deadband and
+    # ${min_duty} mapping on the outputs above exist to handle.
+    constant_brightness: true
     gamma_correct: 0
     default_transition_length: ${transition_ms}ms
     on_turn_on:

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -18,9 +18,11 @@
 substitutions:
   name: yeelight-light-lamp9-pro
 
-  # Fade applied when the light turns on or off. The stock firmware fades over
-  # roughly a second; set to 0s for instant switching.
-  transition_length: 1000ms
+  # Fade applied when the light turns on or off, in milliseconds. The stock
+  # firmware fades over roughly a second. This is the power-on default; it is
+  # also adjustable at runtime from the "transition length" number entity, whose
+  # value is stored on the device and survives a reboot.
+  transition_ms: "1000"
 
   # Lowest PWM duty at which the white channels conduct reliably. Measured per
   # unit by driving the raw outputs and finding where the LEDs light without
@@ -39,6 +41,13 @@ esphome:
   name: ${name}
   friendly_name: ${name}
   min_version: 2024.10.0
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          uint32_t ms = (uint32_t) id(transition_number).state;
+          id(bedside_light).set_default_transition_length(ms);
+          id(night_light).set_default_transition_length(ms);
 
 esp32:
   board: esp32doit-devkit-v1
@@ -131,7 +140,7 @@ light:
     id: night_light
     output: output_nightlight
     gamma_correct: 0
-    default_transition_length: ${transition_length}
+    default_transition_length: ${transition_ms}ms
     on_turn_on:
       - light.turn_off: bedside_light
 
@@ -144,7 +153,7 @@ light:
     warm_white_color_temperature: 2700 K
     constant_brightness: true
     gamma_correct: 0
-    default_transition_length: ${transition_length}
+    default_transition_length: ${transition_ms}ms
     on_turn_on:
       - light.turn_off: night_light
 
@@ -205,3 +214,26 @@ binary_sensor:
                         relative_brightness: -5%
                         transition_length: 0.1s
                     - delay: 0.1s
+
+number:
+  # Runtime control over the on/off fade. Applies to both lights. Home Assistant
+  # can also override it per call with the `transition` parameter of
+  # light.turn_on / light.turn_off; this sets the default used when no
+  # transition is given.
+  - platform: template
+    name: "transition length"
+    id: transition_number
+    entity_category: config
+    unit_of_measurement: ms
+    min_value: 0
+    max_value: 5000
+    step: 100
+    initial_value: ${transition_ms}
+    restore_value: true
+    optimistic: true
+    mode: box
+    set_action:
+      - lambda: |-
+          uint32_t ms = (uint32_t) x;
+          id(bedside_light).set_default_transition_length(ms);
+          id(night_light).set_default_transition_length(ms);

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -1,0 +1,207 @@
+# Yeelight Staria Bedside Lamp Pro (YLCT03YL, yeelink.light.lamp9)
+#
+# Variant of yeelight_light_lamp9.yaml for the Pro model, which adds a Qi
+# wireless charger and its status LED. Differences from the base config are
+# documented in docs/yeelink-light-lamp9-staria-pro.md; in short:
+#
+#   * The white channels will not conduct below roughly 6% PWM duty. The base
+#     config drives them straight from the light component, which makes low
+#     brightness drop out entirely and flicker as the colour temperature moves
+#     off the extremes. The template outputs below apply a floor with a deadband.
+#   * GPIO33 is not the status LED drive - it is an ENABLE for the LED's supply
+#     rail. The Qi charger drives the other half of the circuit and decides the
+#     pattern. Both must be active for the LED to light.
+#
+# Verified on a unit with production date 2020-10, ESP32-WROOM-32D. Other
+# revisions may differ - see the hardware notes before assuming the GPIO map.
+
+substitutions:
+  name: yeelight-light-lamp9-pro
+
+  # Fade applied when the light turns on or off. The stock firmware fades over
+  # roughly a second; set to 0s for instant switching.
+  transition_length: 1000ms
+
+  # Lowest PWM duty at which the white channels conduct reliably. Measured per
+  # unit by driving the raw outputs and finding where the LEDs light without
+  # flicker. 6% on the reference unit.
+  min_duty: "0.06"
+
+  # Requests below this are treated as off rather than being lifted to min_duty.
+  # Needed because the light component does not produce an exact zero at the
+  # colour temperature extremes: mired rounding leaves the opposite channel at
+  # ~0.17%, which a plain min_power would raise to full floor and visibly
+  # contaminate the colour. Must sit above that residual and below the duty a
+  # channel receives at the lowest usable brightness.
+  deadband: "0.004"
+
+esphome:
+  name: ${name}
+  friendly_name: ${name}
+  min_version: 2024.10.0
+
+esp32:
+  board: esp32doit-devkit-v1
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+    advanced:
+      ignore_efuse_mac_crc: true
+      ignore_efuse_custom_mac: true
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  min_auth_mode: WPA2
+  # Strongly recommended, especially when flashing over the network: a typo in
+  # the credentials otherwise leaves the lamp unreachable and only recoverable
+  # over UART, which means opening the device.
+  # Keep the suffix short: an AP SSID cannot exceed 32 characters, and it is
+  # built from ${name}.
+  ap:
+    ssid: "${name}-ap"
+
+captive_portal:
+
+ota:
+  platform: esphome
+
+logger:
+  level: DEBUG
+  baud_rate: 0
+
+api:
+
+output:
+  # Raw PWM channels. The floor is applied by the wrappers below rather than by
+  # min_power, so that a true zero stays a true zero.
+  - platform: ledc
+    pin: GPIO2
+    id: pwm_warm
+    power_supply: power
+  - platform: ledc
+    pin: GPIO27
+    id: pwm_cold
+    power_supply: power
+
+  - platform: template
+    id: output_warm
+    type: float
+    write_action:
+      - lambda: |-
+          if (state < ${deadband}f) {
+            id(pwm_warm).set_level(0.0f);
+          } else {
+            id(pwm_warm).set_level(${min_duty}f + state * (1.0f - ${min_duty}f));
+          }
+  - platform: template
+    id: output_cold
+    type: float
+    write_action:
+      - lambda: |-
+          if (state < ${deadband}f) {
+            id(pwm_cold).set_level(0.0f);
+          } else {
+            id(pwm_cold).set_level(${min_duty}f + state * (1.0f - ${min_duty}f));
+          }
+
+  # The night light uses a separate driver and dims cleanly to well under 1%,
+  # so it needs no floor.
+  - platform: ledc
+    pin: GPIO12
+    id: output_nightlight
+    power_supply: power
+
+  # Status LED ENABLE - see the hardware notes. This drives a transistor that
+  # powers the LED's supply rail; it does not drive the LED itself.
+  - platform: gpio
+    pin: GPIO33
+    id: led_output
+
+power_supply:
+  - id: power
+    pin: GPIO4
+    enable_time: 0s
+    keep_on_time: 2s
+
+light:
+  - platform: monochromatic
+    name: "night light"
+    id: night_light
+    output: output_nightlight
+    gamma_correct: 0
+    default_transition_length: ${transition_length}
+    on_turn_on:
+      - light.turn_off: bedside_light
+
+  - platform: cwww
+    name: "bedside light"
+    id: bedside_light
+    cold_white: output_cold
+    warm_white: output_warm
+    cold_white_color_temperature: 6500 K
+    warm_white_color_temperature: 2700 K
+    constant_brightness: true
+    gamma_correct: 0
+    default_transition_length: ${transition_length}
+    on_turn_on:
+      - light.turn_off: night_light
+
+  # Enabling this permits the charger to light the status LED; it does not light
+  # it, and it cannot change the pattern (steady while charging, blinking when
+  # the phone is not aligned). Defaults to on so the lamp behaves like stock.
+  # Turning it off suppresses the charge indicator, e.g. at night.
+  - platform: binary
+    name: "charger status LED enable"
+    id: led_enable
+    output: led_output
+    restore_mode: RESTORE_DEFAULT_ON
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO14
+      inverted: true
+    name: "button"
+    id: button
+    on_click:
+      then:
+        - if:
+            condition:
+              light.is_off: bedside_light
+            then:
+              light.turn_on:
+                id: bedside_light
+                brightness: 1.0
+            else:
+              light.turn_off: bedside_light
+    on_press:
+      then:
+        - if:
+            condition:
+              light.is_off: bedside_light
+            then:
+              - delay: 0.5s
+              - while:
+                  condition:
+                    binary_sensor.is_on: button
+                  then:
+                    - light.dim_relative:
+                        id: bedside_light
+                        relative_brightness: 5%
+                        transition_length: 0.1s
+                    - delay: 0.1s
+            else:
+              - delay: 0.5s
+              - while:
+                  condition:
+                    and:
+                      - binary_sensor.is_on: button
+                      - light.is_on: bedside_light
+                  then:
+                    - light.dim_relative:
+                        id: bedside_light
+                        relative_brightness: -5%
+                        transition_length: 0.1s
+                    - delay: 0.1s

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -29,6 +29,23 @@ substitutions:
   # flicker. 6% on the reference unit.
   min_duty: "0.06"
 
+  # --- button behaviour ---------------------------------------------------
+  # Brightness and colour temperature form one continuous ramp axis:
+  #
+  #   1% @ warmest  <-->  100% @ warmest  <-->  100% @ mid colour temperature
+  #
+  # Holding the button travels along it. Mid CT is the top end because both LED
+  # channels run at full duty there, which is the brightest the lamp gets.
+  button_min_brightness_pct: "1"
+  button_step_pct: "5"
+  button_ct_step_mireds: "8"
+  button_step_interval_ms: "100"
+  button_hold_time: 500ms
+
+  # Whether the ramp continues past 100% brightness into colour temperature.
+  # false stops it at full brightness.
+  button_ramp_ct: "true"
+
   # Requests below this are treated as off rather than being lifted to min_duty.
   # Needed because the light component does not produce an exact zero at the
   # colour temperature extremes: mired rounding leaves the opposite channel at
@@ -128,6 +145,21 @@ output:
     pin: GPIO33
     id: led_output
 
+globals:
+  # Direction the next hold travels. Flips after every hold, so a hold that
+  # dimmed down is followed by one that brightens.
+  - id: ramp_up
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  # True while the ramp is running, so its own light changes are distinguishable
+  # from external ones.
+  - id: button_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
 power_supply:
   - id: power
     pin: GPIO4
@@ -151,7 +183,16 @@ light:
     warm_white: output_warm
     cold_white_color_temperature: 6500 K
     warm_white_color_temperature: 2700 K
-    constant_brightness: true
+    # Remember brightness and colour temperature across a power cycle but
+    # come back off - this is what makes 'restore last state' work.
+    restore_mode: RESTORE_AND_OFF
+    # false, not true. With constant_brightness the channel sum is normalised to
+    # a constant, so both channels can never run at full: mid colour temperature
+    # gives 50%/50% instead of 100%/100%, and the lamp tops out at one channel's
+    # worth of output. With it off, the mired midpoint drives both channels at
+    # 100% - twice the light, and what the stock firmware does. Brightness then
+    # varies with colour temperature, which is the stock behaviour too.
+    constant_brightness: false
     gamma_correct: 0
     default_transition_length: ${transition_ms}ms
     on_turn_on:
@@ -174,46 +215,113 @@ binary_sensor:
       inverted: true
     name: "button"
     id: button
+
+    # A click toggles. max_length keeps a hold from also firing this on release,
+    # which would otherwise undo whatever the ramp just did.
     on_click:
+      min_length: 20ms
+      max_length: ${button_hold_time}
       then:
         - if:
             condition:
               light.is_off: bedside_light
             then:
-              light.turn_on:
-                id: bedside_light
-                brightness: 1.0
+              - if:
+                  condition:
+                    switch.is_on: restore_on_turn_on
+                  then:
+                    # No values given, so the light returns as it was left.
+                    - light.turn_on:
+                        id: bedside_light
+                  else:
+                    - light.turn_on:
+                        id: bedside_light
+                        brightness: !lambda "return id(preset_brightness).state / 100.0f;"
+                        color_temperature: !lambda |-
+                          auto tr = id(bedside_light).get_traits();
+                          float warmest = tr.get_max_mireds();
+                          float coldest = tr.get_min_mireds();
+                          return warmest - (id(preset_color_temp).state / 100.0f) *
+                                           (warmest - coldest);
             else:
-              light.turn_off: bedside_light
+              - light.turn_off: bedside_light
+
+    # Anything longer than button_hold_time is a hold, and ramps.
     on_press:
       then:
+        - delay: ${button_hold_time}
         - if:
             condition:
-              light.is_off: bedside_light
+              binary_sensor.is_on: button
             then:
-              - delay: 0.5s
+              - lambda: "id(button_active) = true;"
+              - if:
+                  condition:
+                    light.is_off: bedside_light
+                  then:
+                    # From off we start at the bottom of the axis - minimum
+                    # brightness at the warmest setting - and ramp up.
+                    - lambda: "id(ramp_up) = true;"
+                    - light.turn_on:
+                        id: bedside_light
+                        brightness: !lambda "return ${button_min_brightness_pct} / 100.0f;"
+                        color_temperature: !lambda |-
+                          return id(bedside_light).get_traits().get_max_mireds();
+                        transition_length: 0s
               - while:
                   condition:
                     binary_sensor.is_on: button
                   then:
-                    - light.dim_relative:
-                        id: bedside_light
-                        relative_brightness: 5%
-                        transition_length: 0.1s
-                    - delay: 0.1s
-            else:
-              - delay: 0.5s
-              - while:
-                  condition:
-                    and:
-                      - binary_sensor.is_on: button
-                      - light.is_on: bedside_light
-                  then:
-                    - light.dim_relative:
-                        id: bedside_light
-                        relative_brightness: -5%
-                        transition_length: 0.1s
-                    - delay: 0.1s
+                    - lambda: |-
+                        auto *lt = id(bedside_light);
+                        auto tr = lt->get_traits();
+                        const float coldest = tr.get_min_mireds();
+                        const float warmest = tr.get_max_mireds();
+                        const float mid = (coldest + warmest) / 2.0f;
+                        const float min_br = ${button_min_brightness_pct} / 100.0f;
+                        const float d_br = ${button_step_pct} / 100.0f;
+                        const float d_ct = ${button_ct_step_mireds};
+                        const bool use_ct = ${button_ramp_ct};
+
+                        float br = lt->remote_values.get_brightness();
+                        float ct = lt->remote_values.get_color_temperature();
+
+                        auto call = lt->make_call();
+                        uint32_t iv = (uint32_t)(1000.0f * ${button_step_pct} /
+                                                 id(ramp_speed).state);
+                        call.set_transition_length(iv);
+
+                        if (id(ramp_up)) {
+                          if (br < 0.999f) {
+                            call.set_brightness(fminf(br + d_br, 1.0f));
+                          } else if (use_ct && ct > mid + 0.5f) {
+                            call.set_color_temperature(fmaxf(ct - d_ct, mid));
+                          } else {
+                            return;
+                          }
+                        } else {
+                          if (use_ct && ct < warmest - 0.5f) {
+                            call.set_color_temperature(fminf(ct + d_ct, warmest));
+                          } else if (br > min_br) {
+                            call.set_brightness(fmaxf(br - d_br, min_br));
+                          } else {
+                            return;
+                          }
+                        }
+                        call.perform();
+                    - delay: !lambda "return (uint32_t)(1000.0f * ${button_step_pct} / id(ramp_speed).state);"
+              # Flip for next time, so successive holds alternate direction.
+              - lambda: |-
+                  id(ramp_up) = !id(ramp_up);
+                  id(button_active) = false;
+
+switch:
+  - platform: template
+    name: "restore state on turn on"
+    id: restore_on_turn_on
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
 
 number:
   # Runtime control over the on/off fade. Applies to both lights. Home Assistant
@@ -237,3 +345,49 @@ number:
           uint32_t ms = (uint32_t) x;
           id(bedside_light).set_default_transition_length(ms);
           id(night_light).set_default_transition_length(ms);
+
+
+  # Used when "restore state on turn on" is off. Colour temperature is a
+  # percentage of the lamp's range: 0% warmest, 100% coldest, so 50% is the
+  # midpoint where both channels run at full duty.
+  - platform: template
+    name: "preset brightness"
+    id: preset_brightness
+    entity_category: config
+    unit_of_measurement: "%"
+    min_value: 1
+    max_value: 100
+    step: 1
+    initial_value: 100
+    restore_value: true
+    optimistic: true
+    mode: box
+
+  - platform: template
+    name: "preset color temperature"
+    id: preset_color_temp
+    entity_category: config
+    unit_of_measurement: "%"
+    min_value: 0
+    max_value: 100
+    step: 1
+    initial_value: 50
+    restore_value: true
+    optimistic: true
+    mode: box
+
+
+  # Brightness percent per second while the button is held. The colour
+  # temperature stage of the ramp scales with it.
+  - platform: template
+    name: "ramp speed"
+    id: ramp_speed
+    entity_category: config
+    unit_of_measurement: "%/s"
+    min_value: 10
+    max_value: 200
+    step: 5
+    initial_value: 50
+    restore_value: true
+    optimistic: true
+    mode: box


### PR DESCRIPTION
## What this adds

A config for the **Staria Bedside Lamp Pro** (`YLCT03YL`, which reports as
`yeelink.light.lamp9`), plus the hardware notes behind it and a network-only
flashing route that avoids opening the device at all.

Everything here was measured on a single unit: production date **2020-10**,
**ESP32-WROOM-32D**, stock firmware `2.1.7_0031` / `miio_ver 0.0.9`. The Pro and
the non-Pro Staria report the same internal model, so the model string alone does
not tell you which board is inside. Tuned values are substitutions rather than
constants for that reason.

`yeelight_light_lamp9_pro.yaml` is a separate file rather than a change to
`yeelight_light_lamp9.yaml`, so nothing existing is affected.

## Why

### The white channels will not dim

The constant-current driver stops conducting below roughly **6% PWM duty**. Below
about 4% brightness the light goes fully dark, and at ~5% it drops out or flickers
as soon as the colour temperature moves off the extremes — because
`constant_brightness` splits the request across both channels, so each one falls
under the threshold while their sum does not.

`min_power` is not the fix. It lifts *every* non-zero value, and `zero_means_zero`
only catches an exact `0.0`. A request for the warm end arrives rounded in mireds
and leaves the opposite channel at ~0.17% rather than 0, which `min_power` then
raises to the full floor — "maximum warm" comes out visibly cold. The config uses
template outputs applying a **deadband**: a true zero below the threshold, the
floor at or above it.

### `constant_brightness: true` caps the lamp at half its output

ESPHome normalises the channel fractions so `max(cw, ww) == 1`, and
`constant_brightness` then holds their sum constant. At 100% brightness:

| Colour temp | `true` | `false` |
| ----------- | ------ | ------- |
| 2700K warm  | one channel 100%, sum 100% | one channel 100%, sum 100% |
| 3815K       | each 50%, sum 100%         | **both 100%, sum 200%** |
| 6500K cold  | one channel 100%, sum 100% | one channel 100%, sum 100% |

So with it on, both channels can never run at full and half the available light is
unreachable. This config uses **false**, which makes the mired midpoint the
maximum-output point and matches the stock firmware. Brightness then varies with
colour temperature — the stock lamp does that too.

Worth knowing where that midpoint appears in Home Assistant: mireds are
reciprocal to Kelvin and the HA slider is linear in Kelvin, so 3815K sits at about
**29%** of a 2700-6500K slider rather than halfway along.

### The status LED is an AND gate across two boards

The GPIO table lists `LED (YLCT03YL only) → GPIO33`. GPIO33 does not drive that
LED — it drives a transistor that **enables the LED's supply rail**, while the Qi
charger drives the other half of the circuit and decides the pattern (steady while
charging, blinking when the phone is misaligned). Both must conduct for the LED to
light.

This is easy to misdiagnose: toggling GPIO33 with no phone on the charger does
nothing at all, which looks exactly like a dead LED or a wrong pin. Traced on the
PCB, with component references, in the hardware notes.

The charger's only signal terminates at a transistor base that connects to no
ESP32 pin, so **charge state cannot be read** — verified by continuity against
every module castellation, and by sampling every free GPIO and both plausible I2C
buses while a phone was placed, moved off-centre and removed.

### Button behaviour differed from stock

Tested side by side against a stock lamp. Brightness and colour temperature are
treated as one continuous ramp axis:

```
1% @ warmest  <-->  100% @ warmest  <-->  100% @ mired midpoint
```

Holding travels along it; up does brightness then colour temperature, down
reverses colour temperature to warm before dimming. Also fixed: ramping up from
off did nothing (`dim_relative` on an off light has nothing to raise), dimming
down walked into off instead of stopping at a minimum, and `on_click` had no
`max_length` so every hold also fired the click on release and undid the ramp.

Ramp speed, transition length, and a restore-previous-state versus preset-values
switch are exposed as entities.

## Flashing over the network

`docs/flashing-over-the-network.md` plus three helpers in `tools/`. Confirmed on
this unit; third parties report the same mechanism on `yeelink.light.ceiling22`,
which was not verified here.

`miIO.ota` sent **locally** over UDP 54321 with a valid token is refused with
`-30020 "service not available."` — identically whether the payload is empty or
fully populated, across five shapes, so the refusal sits above the parameter
layer. The same command **relayed through the Xiaomi cloud** is accepted, and
`app_url` may point at a private LAN address over plain HTTP:

```
POST https://<region>.api.io.mi.com/app/home/rpc/<did>
data = {"id":N,"method":"miIO.ota","params":{"app_url":"http://<lan-ip>:8000/fw_crc.bin"}}
```

The cloud only relays the instruction; the firmware file never leaves the LAN.
Two requirements are easy to miss:

1. **A 4-byte CRC trailer.** Xiaomi's images are a normal ESP-IDF application
   image followed by four bytes, and it is *not* a catalogued CRC-32 variant:
   polynomial `0x04C11DB7`, **init `0`, no final XOR**, reflected, stored
   little-endian — standard CRC-32 without the customary inversions. Verified
   against two unrelated Xiaomi images, one ESP32 and one MT7697, both reproducing
   exactly. `tools/append_crc.py` implements and self-verifies it.
2. **HTTP/1.1.** The downloader (`User-Agent: MIoT`) connects to an HTTP/1.0
   server, starts reading, then resets — three times — and returns to `idle` with
   nothing written. Python's `http.server` answers HTTP/1.0 and ignores `Range`,
   so it fails. `tools/ota_server.py` speaks HTTP/1.1 with range support and logs
   what the device actually requests.

Confirmed non-destructive: an OTA pointed at a **404** (the device fetches, fails,
returns to `idle` unharmed — a safe way to prove the path end to end), aborted
transfers, and unknown miIO methods. The **install** stage is where the risk is
and was not probed beyond a successful flash; it writes only the application
partition, so it cannot rescue a device that will not boot.

Always include `ap:` and `captive_portal:` when flashing this way. During this
work an SSID picked up a trailing `\r` from a CRLF file, the lamp came up on
ESPHome unable to join, and the fallback AP turned a teardown into a two-minute
captive-portal fix.

## Caveats

- One unit, one hardware revision. The GPIO map, the 6% floor and the LED circuit
  may not hold elsewhere.
- `yeelight_light_lamp9_pro.yaml` has not been tested on any other device.
- The status LED circuit was traced with a multimeter; the part marked `R1A` was
  not identified and its role is inferred from where its legs go.
- `esphome config`, `yamllint` and `ruff` all pass.
