### PR TITLE
Extract the stock firmware with the ESPHome image that replaced it, and restore it over ESPHome OTA; Flashing over UART docs and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ ESPHome custom firmware for ESP32 based Yeelight Ceiling Lights.
 | Yeelight Ceiling Light 400C                      | yeelight.light.ceilb      | YLXDD-0034  | AC220V, 24W, 2000lm, 2700K-6500K, RGB ambient light |
 | Yeelight Jiaoyue 260 Ceiling Light               | yeelight.light.ceiling24  | YLXD62YI    | AC220V, 10W, 670LM, 2700K-6500K, 26cm |
 
+### Flashing over UART
+
+The per-model pinouts below say which pads to use. For what goes wrong once they
+are wired - grounding, powering the board, download mode, and reading esptool's
+misleading errors - see
+[docs/flashing-over-uart.md](docs/flashing-over-uart.md).
+
 ### Flashing without opening the device
 
 Every procedure in this repository flashes over UART. On ESP32 models running
@@ -49,9 +56,10 @@ mechanism, relayed through the Xiaomi cloud, pointed at a file on your LAN.
 See [docs/flashing-over-the-network.md](docs/flashing-over-the-network.md) and
 the helpers in [`tools/`](tools).
 
-Confirmed on `yeelink.light.lamp9` firmware 2.1.7_0031. It writes only the
-application partition, so it cannot rescue a device that will not boot - that
-still needs UART.
+Confirmed on `yeelink.light.lamp9` firmware 2.1.7_0031 and
+`yeelink.light.ceiling10` firmware 2.0.6_0049; the requirements differ between
+those two firmware generations. It writes only the application partition, so it
+cannot rescue a device that will not boot - that still needs UART.
 
 ### More ESPHome + Yeelight projects
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -5,38 +5,24 @@ the device apart. On ESP32 Yeelights running stock firmware there is another
 route: the device's own `miIO.ota` update mechanism can be pointed at a file on
 your LAN.
 
-Confirmed here on `yeelink.light.lamp9` firmware `2.1.7_0031`
-(`miio_ver 0.0.9`). Third parties report the same mechanism working on
-`yeelink.light.ceiling22`; that was not verified as part of this work.
+Confirmed here on two units of different firmware generations:
+`yeelink.light.lamp9` on `2.1.7_0031` (`miio_ver 0.0.9`) and
+`yeelink.light.ceiling10` on `2.0.6_0049` (`miio_ver 0.0.6`). The requirements
+differ between them - see the table further down. Third parties report the same
+mechanism working on `yeelink.light.ceiling22`; that was not verified here.
 
 > **Read the limits first.** This writes only the application partition. The
 > stock bootloader and partition table remain, so it cannot recover a device that
-> will not boot - that still needs UART. Take a flash backup over UART first if
-> you want any way back, because no stock firmware image for these models is
-> archived anywhere public.
+> will not boot - that still needs UART.
+>
+> It is worth knowing what recovery you do have. The vendor's current stock image
+> for a given model can be fetched from Xiaomi's cloud - see
+> `docs/xiaomi-cloud-firmware.md` - so a way back exists without a UART backup,
+> though only to the *current* build, since older versions are not downloadable.
+> Separately, the updater writes to the inactive OTA slot, so the stock app
+> normally survives a conversion in the other one.
 
 ---
-
-## Why the obvious approach fails
-
-Sending `miIO.ota` **locally** over UDP 54321 with a valid token is refused:
-
-```
-{"code": -30020, "message": "service not available."}
-```
-
-The response is identical with no parameters at all and with a full payload,
-which places the refusal above the parameter layer: five payload shapes were
-tried and none made any difference. Local OTA is disabled on this firmware, and
-the update command has to arrive from the Xiaomi cloud instead.
-
-Useful error signatures when probing:
-
-| Response | Meaning |
-| -------- | ------- |
-| `-9999 user ack timeout` | method not implemented; firmware never acknowledges |
-| `-32602 Invalid param.` | method exists, parameter validation rejected the input |
-| `-30020 service not available.` | method exists, the service refuses before parsing |
 
 ## The route that works
 
@@ -60,6 +46,26 @@ Two things about that payload matter:
   from shipping a bad image.
 
 The cloud only relays the instruction. The firmware file never leaves your LAN.
+
+## What is safe and what is not
+
+Confirmed non-destructive on the reference unit:
+
+- An OTA pointed at a URL returning **404** - the device fetches, fails, returns
+  to `idle`, unharmed. A useful way to prove the path end to end without
+  installing anything.
+- Aborted transfers, including the HTTP/1.0 resets described in requirement 2.
+- Unknown or malformed miIO methods, which are ignored without a reboot.
+
+Not verified, and where the real risk lies:
+
+- The **install** stage. Once a valid image downloads it is written and booted.
+  A third-party report describes an official Yeelight OTA bricking a ceiling
+  light, so this firmware's install path can write something unbootable.
+- The OTA call itself carries no checksum, so nothing at the protocol level
+  distinguishes a correct image from one built for the wrong model. What the
+  firmware checks beyond the CRC trailer, and how it behaves on a bad image, was
+  not tested - deliberately.
 
 ## Four requirements that are easy to miss
 
@@ -220,6 +226,76 @@ strings .pioenvs/<name>/firmware.bin | grep -c "No MD5 found in partition table"
 Setting the option is harmless on a device that does not need it, so it is worth
 having on any config intended for this route.
 
+## Always include a fallback AP
+
+```yaml
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "fallback-ap"
+
+captive_portal:
+```
+
+A wrong credential is otherwise unrecoverable without UART - which defeats the
+entire point of flashing over the network. This is not hypothetical: during this
+work an SSID picked up a trailing `\r` from a CRLF file, the lamp came up on
+ESPHome unable to join, and the fallback AP turned a teardown into a two-minute
+captive-portal fix.
+
+Worth knowing how portal-saved credentials behave, because it is easy to get
+wrong. They are stored in NVS and **replace** the compiled-in ones (`set_sta`, not
+`add_sta`) - so a device can keep running on them while the firmware carries a
+wrong SSID. But the preference is keyed on `App.get_config_version_hash()`, so
+**any configuration change orphans them** and the device falls back to whatever is
+compiled in. They persist across a plain re-flash of the same config, not across
+an edited one.
+
+## Procedure
+
+1. **Recover the device token and `did`** from the Xiaomi cloud. Existing tools
+   cover this; note the Yeelight app account and the Xiaomi account may be the
+   same identity, in which case no re-pairing is needed.
+
+2. **Build the ESPHome image** for your model. Include `ap:` and
+   `captive_portal:` - see "Always include a fallback AP" above, which explains
+   why this is not optional.
+
+3. **Check it fits.** Only the application partition is written and the stock
+   partition table stays, so the image must fit the slot the stock firmware uses.
+   The stock partition table has not been dumped, so the exact slot size is
+   unknown. The `lamp9` ESPHome build used here was 810 KB and installed without
+   trouble.
+
+4. **Append the CRC trailer:**
+
+   ```
+   python3 tools/append_crc.py firmware.bin fw_crc.bin
+   ```
+
+5. **Serve it over HTTP/1.1** and confirm another host on the LAN can fetch the
+   whole file before going further:
+
+   Port **80**, not a high port. Older firmware cannot parse a URL with an
+   explicit port (requirement 3), and port 80 works on every unit tested, so it is
+   the safe default - at the cost of needing root to bind:
+
+   ```
+   sudo python3 tools/ota_server.py fw_crc.bin 80
+   ```
+
+6. **Relay the OTA command through the cloud**, with no port in the URL:
+
+   ```
+   python3 tools/cloud_ota.py --server de --ip <device-ip> \
+       --url http://<your-lan-ip>/fw_crc.bin
+   ```
+
+7. **Watch it land.** `miIO.get_ota_state` walks `idle -> downloading ->
+   installed`, the server logs one full-size `GET`, and the device reboots into
+   ESPHome. The stock protocols (TCP 55443, UDP 54321) go silent.
+
 ## What the flash looks like underneath
 
 Worth knowing before starting, because it determines what recovery is available.
@@ -268,91 +344,26 @@ device rejoins its account by itself.
 Do **not** erase the whole of `otadata`: with no valid record the bootloader falls
 back to the *first* app partition, which is `ota_0` - not necessarily stock.
 
-## Procedure
+## Appendix: why the obvious approach fails
 
-1. **Recover the device token and `did`** from the Xiaomi cloud. Existing tools
-   cover this; note the Yeelight app account and the Xiaomi account may be the
-   same identity, in which case no re-pairing is needed.
+Background, kept for the record. Nothing below is needed to follow
+the procedure above.
 
-2. **Build the ESPHome image** for your model. Include `ap:` and
-   `captive_portal:` - see the warning below.
+Sending `miIO.ota` **locally** over UDP 54321 with a valid token is refused:
 
-3. **Check it fits.** Only the application partition is written and the stock
-   partition table stays, so the image must fit the slot the stock firmware uses.
-   The stock partition table has not been dumped, so the exact slot size is
-   unknown. The `lamp9` ESPHome build used here was 810 KB and installed without
-   trouble.
-
-4. **Append the CRC trailer:**
-
-   ```
-   python3 tools/append_crc.py firmware.bin fw_crc.bin
-   ```
-
-5. **Serve it over HTTP/1.1** and confirm another host on the LAN can fetch the
-   whole file before going further:
-
-   Port **80**, not a high port. Older firmware cannot parse a URL with an
-   explicit port (requirement 3), and port 80 works on every unit tested, so it is
-   the safe default - at the cost of needing root to bind:
-
-   ```
-   sudo python3 tools/ota_server.py fw_crc.bin 80
-   ```
-
-6. **Relay the OTA command through the cloud**, with no port in the URL:
-
-   ```
-   python3 tools/cloud_ota.py --server de --ip <device-ip> \
-       --url http://<your-lan-ip>/fw_crc.bin
-   ```
-
-7. **Watch it land.** `miIO.get_ota_state` walks `idle -> downloading ->
-   installed`, the server logs one full-size `GET`, and the device reboots into
-   ESPHome. The stock protocols (TCP 55443, UDP 54321) go silent.
-
-## Always include a fallback AP
-
-```yaml
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  ap:
-    ssid: "fallback-ap"
-
-captive_portal:
+```
+{"code": -30020, "message": "service not available."}
 ```
 
-A wrong credential is otherwise unrecoverable without UART - which defeats the
-entire point of flashing over the network. This is not hypothetical: during this
-work an SSID picked up a trailing `\r` from a CRLF file, the lamp came up on
-ESPHome unable to join, and the fallback AP turned a teardown into a two-minute
-captive-portal fix.
+The response is identical with no parameters at all and with a full payload,
+which places the refusal above the parameter layer: five payload shapes were
+tried and none made any difference. Local OTA is disabled on this firmware, and
+the update command has to arrive from the Xiaomi cloud instead.
 
-Worth knowing how portal-saved credentials behave, because it is easy to get
-wrong. They are stored in NVS and **replace** the compiled-in ones (`set_sta`, not
-`add_sta`) - so a device can keep running on them while the firmware carries a
-wrong SSID. But the preference is keyed on `App.get_config_version_hash()`, so
-**any configuration change orphans them** and the device falls back to whatever is
-compiled in. They persist across a plain re-flash of the same config, not across
-an edited one.
+Useful error signatures when probing:
 
-## What is safe and what is not
-
-Confirmed non-destructive on the reference unit:
-
-- An OTA pointed at a URL returning **404** - the device fetches, fails, returns
-  to `idle`, unharmed. A useful way to prove the path end to end without
-  installing anything.
-- Aborted transfers, including the HTTP/1.0 resets above.
-- Unknown or malformed miIO methods, which are ignored without a reboot.
-
-Not verified, and where the real risk lies:
-
-- The **install** stage. Once a valid image downloads it is written and booted.
-  A third-party report describes an official Yeelight OTA bricking a ceiling
-  light, so this firmware's install path can write something unbootable.
-- The OTA call itself carries no checksum, so nothing at the protocol level
-  distinguishes a correct image from one built for the wrong model. What the
-  firmware checks beyond the CRC trailer, and how it behaves on a bad image, was
-  not tested - deliberately.
+| Response | Meaning |
+| -------- | ------- |
+| `-9999 user ack timeout` | method not implemented; firmware never acknowledges |
+| `-32602 Invalid param.` | method exists, parameter validation rejected the input |
+| `-30020 service not available.` | method exists, the service refuses before parsing |

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -67,20 +67,20 @@ Not verified, and where the real risk lies:
   firmware checks beyond the CRC trailer, and how it behaves on a bad image, was
   not tested - deliberately.
 
-## Four requirements that are easy to miss
+## Five requirements that are easy to miss
 
-Not all four apply to every device, and the differences track the firmware
+Not all five apply to every device, and the differences track the firmware
 generation. Two units were converted, and this is what each one actually showed:
 
 | | `yeelink.light.lamp9`<br>`miio_ver 0.0.9`, stock 2.1.7_0031 | `yeelink.light.ceiling10`<br>`miio_ver 0.0.6`, stock 2.0.6_0049 |
 | --- | --- | --- |
 | 1. CRC trailer | appended; necessity not tested | appended; necessity not tested |
-| 2. HTTP/1.1 | **observed necessary** | not separately tested |
+| 2. HTTP/1.1 | **observed necessary** | served over 1.1 throughout, so never retested |
 | 3. no port in the URL | **not needed** - flashed successfully on port 8000 | **required** |
 | 4. `PARTITION_TABLE_MD5: n` | **not needed** - booted fine without it | **required** |
-| `FREERTOS_UNICORE: y` | used | required; die confirmed single-core |
+| 5. `FREERTOS_UNICORE: y` | set; necessity not tested | **required**; die confirmed single-core |
 
-So a newer unit may well flash with none of 3 or 4. An older one needs both, and
+So a newer unit may well flash without 3 or 4 at all. An older one needs both, and
 each failure looks like something else entirely - which is why they are written up
 in detail below rather than as a checklist.
 
@@ -125,6 +125,10 @@ Python's `http.server` answers HTTP/1.0 and ignores `Range`, so it fails here.
 Serving byte-identical content over HTTP/1.1 with keep-alive and range support
 works first time. `tools/ota_server.py` is a minimal server that does this and
 logs what the device actually requests.
+
+Every later transfer, `ceiling10` included, was served over HTTP/1.1 by that tool,
+so the failure was never reproduced on the older generation - it simply never had
+the chance to occur.
 
 ### 3. The URL must not contain a port
 
@@ -225,6 +229,34 @@ strings .pioenvs/<name>/firmware.bin | grep -c "No MD5 found in partition table"
 
 Setting the option is harmless on a device that does not need it, so it is worth
 having on any config intended for this route.
+
+### 5. Build for a single core if the die has one
+
+The `ceiling10`'s module is marked `ESP32-WROOM-32D`, which is normally the
+dual-core `D0WD`. The die in it is not:
+
+```
+Chip type: Unknown ESP32 (revision v1.0)
+Features:  Wi-Fi, BT, Single Core + LP Core, 240MHz
+```
+
+An image built for two cores tries to bring up an APP CPU that is not there, and
+faults during startup - before Wi-Fi, so it looks exactly like requirement 4.
+
+```yaml
+esp32:
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+```
+
+Every config in this repository already sets this, which makes it easy to overlook
+when writing a new one from scratch. It was set for the `lamp9` too, so whether
+that unit strictly needs it is unknown - its die was never read.
+
+The lesson is narrower than "check the die": the module marking does not tell you,
+so set the option rather than trusting the label.
 
 ## Always include a fallback AP
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -74,7 +74,7 @@ generation. Two units were converted, and this is what each one actually showed:
 
 | | `yeelink.light.lamp9`<br>`miio_ver 0.0.9`, stock 2.1.7_0031 | `yeelink.light.ceiling10`<br>`miio_ver 0.0.6`, stock 2.0.6_0049 |
 | --- | --- | --- |
-| 1. CRC trailer | appended; necessity not tested | appended; necessity not tested |
+| 1. CRC trailer | appended; necessity not tested | **required** - verified by serving an image without one |
 | 2. HTTP/1.1 | **observed necessary** | served over 1.1 throughout, so never retested |
 | 3. no port in the URL | **not needed** - flashed successfully on port 8000 | **required** |
 | 4. `PARTITION_TABLE_MD5: n` | **not needed** - booted fine without it | **required** |
@@ -89,8 +89,35 @@ in detail below rather than as a checklist.
 
 Xiaomi's own ESP32 update images are a normal ESP-IDF application image - whose
 internal SHA-256 verifies - followed by four extra bytes. A plain ESPHome
-`firmware.bin` has no trailer, so one was appended here to match the vendor
-format. Whether the device rejects an image without it was not tested.
+`firmware.bin` has no trailer, so one must be appended.
+
+**This is enforced.** Serving a `ceiling10` an image with no trailer - byte-identical
+to one it had already accepted and booted, minus the four bytes - it downloads the
+whole file, rejects it, and retries twice more before giving up:
+
+```
+[I] miio_ota: 1 ota task comming...
+[I] httpc: Content-Length 804704
+[I] httpc: ==> 0% ... ==> 100%
+[I] httpc: GET Done(804704bytes).
+[I] httpc: File Done(804704bytes).
+[E] arch_ota: crc check failed!  (arch_ota_check_crc,309)
+[E] ota_app: ota erro count:1 (app_fw_error,366)
+[W] miio_ota: error count = 1 (ota_virtual_error,398)
+        ... two more identical attempts ...
+[E] miio_ota: error occurred too many times (ota_virtual_error,406)
+[I] miio_ota: installed = 0, failed = 1
+```
+
+Three complete downloads and no install. Note the shape of that failure, because
+it is visible without a serial console: **three full-size GETs in the HTTP server
+log, then `miIO.get_ota_state` returning to `idle`** with the device still on stock.
+A trailered image produces exactly one GET and then `installed`.
+
+The device is left untouched by a rejection, so this is a safe thing to get wrong.
+
+The vendor's own function name, `arch_ota_check_crc`, also confirms the trailer is
+a CRC over the image rather than any other kind of tag.
 
 The algorithm is **not** a standard CRC-32; none of the catalogued variants
 reproduce it:
@@ -113,8 +140,8 @@ Xiaomi image you have.
 
 Observed on `lamp9` (`miio_ver 0.0.9`). The device's downloader identifies itself
 as `User-Agent: MIoT`. Against an HTTP/1.0 server it connects, begins reading,
-then resets the connection - three times in quick succession - and returns to
-`idle` with nothing written:
+then resets the connection - three times, the updater's own retry limit, the same
+one seen in requirement 1 - and returns to `idle` with nothing written:
 
 ```
 "GET /fw_crc.bin HTTP/1.1" 200 -

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -61,7 +61,7 @@ Two things about that payload matter:
 
 The cloud only relays the instruction. The firmware file never leaves your LAN.
 
-## Three requirements that are easy to miss
+## Four requirements that are easy to miss
 
 ### 1. The image carries a 4-byte CRC trailer
 
@@ -141,6 +141,106 @@ device**; that is the only evidence the transfer started, and
 and stops as soon as the device leaves `idle`, which is useful when a firmware
 generation wants a different payload - though note that no payload shape helps if
 the URL carries a port.
+
+### 4. The app must tolerate a partition table with no MD5
+
+This one does not stop the transfer. The image downloads, the updater reports
+`installed`, and then the device is bricked in a reboot loop - **silent at every
+layer**. No Wi-Fi, no fallback AP, and power-cycling cannot reach ESPHome's safe
+mode either. Only UART reveals why:
+
+```
+E (344) partition: No MD5 found in partition table
+E (345) partition: load_partitions returned 0x105
+assert failed: esp_ota_get_running_partition esp_ota_ops.c:721 (it != NULL)
+```
+
+ESP-IDF's `CONFIG_PARTITION_TABLE_MD5` defaults to `y`, and
+`components/esp_partition/partition.c` refuses a table with no MD5 record when it
+is set. Its own Kconfig help says the generation "should be turned off for legacy
+bootloaders which cannot recognize the MD5 checksum in the partition table" -
+which is exactly the situation here, because the stock partition table on the
+older firmware generation carries no such record.
+
+`esp_ota_get_running_partition()` then finds nothing and the app asserts **before
+Wi-Fi and before `safe_mode` set up**, which is why none of the usual recovery
+paths exist. Recovery is UART.
+
+The fix is one option:
+
+```yaml
+esp32:
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_PARTITION_TABLE_MD5: n
+```
+
+Nothing on flash changes - the stock bootloader, partition table and layout are
+all left alone; the app simply stops requiring a record that was never there.
+
+Confirm it applied before flashing, because a disabled bool is written as a
+comment rather than `=n`:
+
+```
+grep PARTITION_TABLE_MD5 .esphome/build/<name>/sdkconfig.<name>
+# CONFIG_PARTITION_TABLE_MD5 is not set
+
+strings .pioenvs/<name>/firmware.bin | grep -c "No MD5 found in partition table"
+0
+```
+
+Observed on `yeelink.light.ceiling10` (`miio_ver 0.0.6`); a `lamp9` on `0.0.9`
+does not need it, so its stock table does carry the MD5. Setting the option is
+harmless either way, so it is worth having on any config intended for this route.
+
+## What the flash looks like underneath
+
+Worth knowing before starting, because it determines what recovery is available.
+Read the table with `esptool read-flash 0x8000 0xc00 ptable.bin`. On a
+`ceiling10`:
+
+| label | type | subtype | offset | size |
+| ----- | ---- | ------- | ------ | ---- |
+| nvs | data | nvs | 0x9000 | 16K |
+| otadata | data | otadata | 0xD000 | 8K |
+| phy_init | data | phy | 0xF000 | 4K |
+| miio_fw1 | app | ota_0 | 0x10000 | 1920K |
+| miio_fw2 | app | ota_1 | 0x1F0000 | 1920K |
+| test | app | test | 0x3D0000 | 76K |
+| mfi_p | data | spiffs | 0x3E3000 | 4K |
+| factory_nvs | data | nvs | 0x3E4000 | 16K |
+| coredump | data | coredump | 0x3E8000 | 64K |
+| minvs | data | 0xfe | 0x3F8000 | 16K |
+
+Three things follow from it.
+
+**The app slots are 1920 KB**, so image size is a non-issue: stock itself is about
+1.3 MB and a typical ESPHome build for one of these is well under a megabyte.
+
+**There is no `factory` partition**, so `otadata` alone decides what boots.
+
+**Stock survives the conversion.** The updater writes to the *inactive* slot, so
+after flashing, the original vendor app is still sitting in the other one.
+
+### Getting stock back without reflashing it
+
+`otadata` holds one 32-byte record per 4K sector, at `0xD000` and `0xE000`. Each
+carries a sequence number; the highest valid one wins and selects
+`ota_[(seq-1) % 2]`. After a conversion you will typically find the older record
+still pointing at the slot stock lives in.
+
+So erase the newer record and let the older one win:
+
+```
+esptool erase-region 0xE000 0x1000
+```
+
+NVS survives, so Wi-Fi credentials and the vendor pairing stay intact and the
+device rejoins its account by itself.
+
+Do **not** erase the whole of `otadata`: with no valid record the bootloader falls
+back to the *first* app partition, which is `ota_0` - not necessarily stock.
 
 ## Procedure
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -20,7 +20,8 @@ mechanism working on `yeelink.light.ceiling22`; that was not verified here.
 > `docs/xiaomi-cloud-firmware.md` - so a way back exists without a UART backup,
 > though only to the *current* build, since older versions are not downloadable.
 > Separately, the updater writes to the inactive OTA slot, so the stock app
-> normally survives a conversion in the other one.
+> survives in the other one - but only until the *next* flash, which targets it.
+> See "What the flash looks like underneath" below.
 
 ---
 
@@ -374,15 +375,60 @@ from a `ceiling10`; other models are likely similar but were not dumped.
 | coredump | data | coredump | 0x3E8000 | 64K |
 | minvs | data | 0xfe | 0x3F8000 | 16K |
 
-Three things follow from it.
+Four things follow from it.
 
 **The app slots are 1920 KB**, so image size is a non-issue: stock itself is about
 1.3 MB and a typical ESPHome build for one of these is well under a megabyte.
 
 **There is no `factory` partition**, so `otadata` alone decides what boots.
 
-**Stock survives the conversion.** The updater writes to the *inactive* slot, so
-after flashing, the original vendor app is still sitting in the other one.
+**Stock survives the first flash, and only the first.** Both the vendor updater
+and ESPHome's own OTA write to whatever `esp_ota_get_next_update_partition()`
+returns, which with two slots and no `factory` partition strictly alternates. So
+the conversion lands in the free slot and leaves the vendor app intact; the *next*
+flash targets the slot holding it. If you want that copy, read it out before the
+second flash - see `docs/flashing-over-uart.md`.
+
+**Configuration is not in the app slots at all**, which is what makes going back
+and forth survivable. Details below.
+
+### Configuration lives outside the app slots
+
+There is exactly one `nvs` partition, at `0x9000`, and both firmwares share it.
+No app slot holds any configuration, which is why changing which slot boots does
+not lose your Wi-Fi credentials or the vendor pairing - the stock firmware comes
+back already knowing them.
+
+That is by design rather than luck. `esp_ota_begin()` erases the whole destination
+app partition before writing, so anything kept inside an app partition would die
+on every update. ESP-IDF therefore separates code from settings, and NVS isolates
+writers by **namespace** rather than by partition: ESPHome opens
+`nvs_open("esphome", ...)` and the stock firmware uses its own names. Keys cannot
+collide, but the 16 KB and its free space are shared, so the two are isolated
+logically, not physically.
+
+The captive-portal behaviour described earlier is the same mechanism one level
+down - those credentials are NVS entries keyed on
+`App.get_config_version_hash()`, which is why a configuration change orphans them.
+
+Two paths erase the *whole* `nvs` partition, vendor keys included:
+
+- the `factory_reset` component - button, switch or action - calls
+  `global_preferences->reset()`, which calls `nvs_flash_erase()`;
+- failing to open the `esphome` namespace at startup, after which ESPHome erases
+  NVS and retries. A full NVS would trigger this silently.
+
+So keep `factory_reset` out of any configuration for a device whose vendor pairing
+you want to survive a return to stock. `nvs_flash_erase()` acts only on the
+partition named `nvs`, so `factory_nvs` and `minvs` are not affected by it.
+
+What the other data partitions hold has **not been established** - none of them
+have been read. Going by labels, subtypes and sizes alone: `factory_nvs` is a
+second NVS whose name suggests factory-provisioned identity, `minvs` uses a custom
+subtype (`0xfe`) and so is presumably miio-specific, `mfi_p` is a 4 KB SPIFFS
+whose name points at Apple MFi and therefore plausibly HomeKit pairing, and
+`phy_init` holds RF calibration. Which partition stores the device token is
+unknown for the same reason.
 
 ### Getting stock back without reflashing it
 

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -63,6 +63,22 @@ The cloud only relays the instruction. The firmware file never leaves your LAN.
 
 ## Four requirements that are easy to miss
 
+Not all four apply to every device, and the differences track the firmware
+generation. Two units were converted, and this is what each one actually showed:
+
+| | `yeelink.light.lamp9`<br>`miio_ver 0.0.9`, stock 2.1.7_0031 | `yeelink.light.ceiling10`<br>`miio_ver 0.0.6`, stock 2.0.6_0049 |
+| --- | --- | --- |
+| 1. CRC trailer | appended; necessity not tested | appended; necessity not tested |
+| 2. HTTP/1.1 | **observed necessary** | not separately tested |
+| 3. no port in the URL | **not needed** - flashed successfully on port 8000 | **required** |
+| 4. `PARTITION_TABLE_MD5: n` | **not needed** - booted fine without it | **required** |
+| `FREERTOS_UNICORE: y` | used | required; die confirmed single-core |
+
+So a newer unit may well flash with none of 3 or 4. An older one needs both, and
+each failure looks like something else entirely - which is why they are written up
+in detail below rather than as a checklist.
+
+
 ### 1. The image carries a 4-byte CRC trailer
 
 Xiaomi's own ESP32 update images are a normal ESP-IDF application image - whose
@@ -80,17 +96,19 @@ CRC-32, polynomial 0x04C11DB7 (reflected 0xEDB88320)
 ```
 
 That is standard CRC-32 without the customary pre- and post-inversion. Verified
-against two unrelated Xiaomi images - one ESP32, one MT7697 - which both
-reproduce exactly.
+against five unrelated Xiaomi images which all reproduce exactly: one MT7697, and
+the stock ESP32 images for `yeelink.light.ceiling10`, `lamp9`, `ceilb` and one
+further ESP32 product.
 
 `tools/append_crc.py` implements it, and can verify itself against any genuine
 Xiaomi image you have.
 
 ### 2. The HTTP server must speak HTTP/1.1
 
-The device's downloader identifies itself as `User-Agent: MIoT`. Against an
-HTTP/1.0 server it connects, begins reading, then resets the connection - three
-times in quick succession - and returns to `idle` with nothing written:
+Observed on `lamp9` (`miio_ver 0.0.9`). The device's downloader identifies itself
+as `User-Agent: MIoT`. Against an HTTP/1.0 server it connects, begins reading,
+then resets the connection - three times in quick succession - and returns to
+`idle` with nothing written:
 
 ```
 "GET /fw_crc.bin HTTP/1.1" 200 -
@@ -125,15 +143,20 @@ the HTTP server: a switch does not forward the device's DNS queries to another
 port, so a capture there shows nothing either way. It was only visible from the
 router.
 
-Observed on `yeelink.light.ceiling10` (`miio_ver 0.0.6`). Whether the newer
-`0.0.9` firmware parses a port correctly was not tested - the working `lamp9`
-flash happened to use port 80.
+**This is generation-specific.** Observed on `ceiling10` (`miio_ver 0.0.6`). The
+`lamp9` on `0.0.9` does **not** have the bug: it was flashed successfully with
+`--url http://<ip>:8000/fw_crc.bin`, which is why the procedure below originally
+specified port 8000.
+
+Port 80 is nevertheless the right default, because it works on both and costs
+only a `sudo`.
 
 #### Corollary: what counts as success
 
 `["ok"]` is the cloud acknowledging the relay, not the device agreeing to do
-anything, and on some firmware `miIO.ota` reboots the device about eight seconds
-later whether or not it downloads. **Watch the HTTP server log for a GET from the
+anything. On `ceiling10` (`0.0.6`), `miIO.ota` also reboots the device about eight
+seconds after it is accepted whether or not a download follows, so a failed
+attempt power-cycles the light. **Watch the HTTP server log for a GET from the
 device**; that is the only evidence the transfer started, and
 `miIO.get_ota_state` moving `idle -> downloading -> installed` confirms it.
 
@@ -143,6 +166,10 @@ generation wants a different payload - though note that no payload shape helps i
 the URL carries a port.
 
 ### 4. The app must tolerate a partition table with no MD5
+
+**Also generation-specific**, and observed on `ceiling10` (`miio_ver 0.0.6`); the
+`lamp9` on `0.0.9` booted an image built without this option, so its stock table
+does carry the MD5 record.
 
 This one does not stop the transfer. The image downloads, the updater reports
 `installed`, and then the device is bricked in a reboot loop - **silent at every
@@ -190,15 +217,14 @@ strings .pioenvs/<name>/firmware.bin | grep -c "No MD5 found in partition table"
 0
 ```
 
-Observed on `yeelink.light.ceiling10` (`miio_ver 0.0.6`); a `lamp9` on `0.0.9`
-does not need it, so its stock table does carry the MD5. Setting the option is
-harmless either way, so it is worth having on any config intended for this route.
+Setting the option is harmless on a device that does not need it, so it is worth
+having on any config intended for this route.
 
 ## What the flash looks like underneath
 
 Worth knowing before starting, because it determines what recovery is available.
-Read the table with `esptool read-flash 0x8000 0xc00 ptable.bin`. On a
-`ceiling10`:
+Read the table with `esptool read-flash 0x8000 0xc00 ptable.bin`. Layout below is
+from a `ceiling10`; other models are likely similar but were not dumped.
 
 | label | type | subtype | offset | size |
 | ----- | ---- | ------- | ------ | ---- |
@@ -266,8 +292,9 @@ back to the *first* app partition, which is `ota_0` - not necessarily stock.
 5. **Serve it over HTTP/1.1** and confirm another host on the LAN can fetch the
    whole file before going further:
 
-   Port **80**, not a high port - the updater cannot parse a URL with an
-   explicit port (see requirement 3), so binding 80 needs root:
+   Port **80**, not a high port. Older firmware cannot parse a URL with an
+   explicit port (requirement 3), and port 80 works on every unit tested, so it is
+   the safe default - at the cost of needing root to bind:
 
    ```
    sudo python3 tools/ota_server.py fw_crc.bin 80

--- a/docs/flashing-over-the-network.md
+++ b/docs/flashing-over-the-network.md
@@ -11,9 +11,12 @@ Confirmed here on two units of different firmware generations:
 differ between them - see the table further down. Third parties report the same
 mechanism working on `yeelink.light.ceiling22`; that was not verified here.
 
-> **Read the limits first.** This writes only the application partition. The
-> stock bootloader and partition table remain, so it cannot recover a device that
-> will not boot - that still needs UART.
+> **Read the limits first.** The procedure here writes only the application
+> partition. The stock bootloader and partition table remain, so it cannot recover
+> a device that will not boot - that still needs UART, since a device that does not
+> boot is not on the network either. (ESPHome does document writing the partition
+> table and bootloader over the air; that was not tested here - see "Replacing the
+> partition table or bootloader" below.)
 >
 > It is worth knowing what recovery you do have. The vendor's current stock image
 > for a given model can be fetched from Xiaomi's cloud - see
@@ -22,6 +25,13 @@ mechanism working on `yeelink.light.ceiling22`; that was not verified here.
 > Separately, the updater writes to the inactive OTA slot, so the stock app
 > survives in the other one - but only until the *next* flash, which targets it.
 > See "What the flash looks like underneath" below.
+>
+> That surviving copy can be read out **over the network**, and written back the
+> same way, with no UART and no teardown - which also covers the case the cloud
+> cannot: a build older than current, or a model the endpoint does not serve. It
+> has to be set up before the conversion, though, because the image that replaces
+> stock is the only one that can still reach it. See "Reading the stock image out
+> over the network" below, and enable `flash_probe.yaml` at step 2.
 
 ---
 
@@ -136,6 +146,14 @@ further ESP32 product.
 
 `tools/append_crc.py` implements it, and can verify itself against any genuine
 Xiaomi image you have.
+
+**The trailer is stored in flash, not consumed by the updater.** Reading a
+converted `lamp9`'s stock slot back shows the image ending at its ESP-IDF length
+of 1,494,080 bytes with `0414c948` in the four bytes immediately after - the same
+trailer the served file carried. Two things follow. Restoring such an image
+byte-for-byte reproduces what the vendor wrote, trailer included; and
+`esp_image_verify()` accepts it, because bytes past the declared image end are
+never examined. Both were confirmed by restoring one.
 
 ### 2. The HTTP server must speak HTTP/1.1
 
@@ -322,11 +340,16 @@ an edited one.
    `captive_portal:` - see "Always include a fallback AP" above, which explains
    why this is not optional.
 
+   If you want a copy of the vendor firmware, uncomment the `flash_probe.yaml`
+   include at the top of the device config **now**. This is the only flash after
+   which stock is still readable: the next one overwrites it, so an image without
+   this cannot be used to rescue the copy it is sitting next to.
+
 3. **Check it fits.** Only the application partition is written and the stock
    partition table stays, so the image must fit the slot the stock firmware uses.
-   The stock partition table has not been dumped, so the exact slot size is
-   unknown. The `lamp9` ESPHome build used here was 810 KB and installed without
-   trouble.
+   The slots are **1,966,080 bytes** (0x1E0000) on both models dumped here, and
+   stock itself is about 1.4 MB, so a typical ESPHome build has well over a
+   megabyte of headroom. The `lamp9` builds used here were 810 KB and 828 KB.
 
 4. **Append the CRC trailer:**
 
@@ -359,8 +382,14 @@ an edited one.
 ## What the flash looks like underneath
 
 Worth knowing before starting, because it determines what recovery is available.
-Read the table with `esptool read-flash 0x8000 0xc00 ptable.bin`. Layout below is
-from a `ceiling10`; other models are likely similar but were not dumped.
+Read the table with `esptool read-flash 0x8000 0xc00 ptable.bin` over UART, or
+without opening the device by enabling `flash_probe.yaml`, whose `debug`
+component logs the whole table at boot.
+
+Dumped on two units of different firmware generations - `ceiling10` on `2.0.6`
+over UART, `lamp9` on `2.1.7` over the network - and the two are **identical**,
+label for label and byte for byte. That is worth knowing before assuming a new
+model differs, though it is still two data points.
 
 | label | type | subtype | offset | size |
 | ----- | ---- | ------- | ------ | ---- |
@@ -387,7 +416,8 @@ and ESPHome's own OTA write to whatever `esp_ota_get_next_update_partition()`
 returns, which with two slots and no `factory` partition strictly alternates. So
 the conversion lands in the free slot and leaves the vendor app intact; the *next*
 flash targets the slot holding it. If you want that copy, read it out before the
-second flash - see `docs/flashing-over-uart.md`.
+second flash - over the network as described below, or over UART per
+`docs/flashing-over-uart.md`.
 
 **Configuration is not in the app slots at all**, which is what makes going back
 and forth survivable. Details below.
@@ -448,6 +478,156 @@ device rejoins its account by itself.
 
 Do **not** erase the whole of `otadata`: with no valid record the bootloader falls
 back to the *first* app partition, which is `ota_0` - not necessarily stock.
+
+The records were read off a converted `lamp9` and behave exactly as described:
+`seq` 4 and 3, the higher one flagged `ota_state = 0x02` (valid) and the other
+`0xFFFFFFFF` (undefined), selecting `ota_[(4-1) % 2]` = `ota_1` = `miio_fw2` -
+which was the slot the device reported running.
+
+### Reading the stock image out over the network
+
+The `otadata` trick above only works while the vendor copy is still in a slot. It
+does not survive a second flash, and it cannot help at all on a device whose stock
+build the cloud no longer serves. Reading the image out gives you a file instead,
+and needs no UART.
+
+**Set it up before converting.** Uncomment the include at the top of the device
+config:
+
+```yaml
+packages:
+  flash_probe: !include flash_probe.yaml
+```
+
+That adds four read-only API actions - `dump_flash`, `dump_otadata`, `log_slots`,
+`redump_config` - implemented in `tools/probe_flash.h`. It does **not** enable
+`allow_partition_access`, which gates partition-table and bootloader *writes* and
+carries its own bricking warning; none of this needs it.
+
+`dump_flash` reads `esp_ota_get_next_update_partition()` - the slot this build is
+not running from, which after exactly one flash is the one holding stock - and
+logs it as base64, one chunk per line. `tools/dump_stock.py` drives that loop,
+reassembles the chunks and is restartable, because it records completed offsets
+in a sidecar next to the output file:
+
+```
+python3 tools/dump_stock.py <device-ip> stock.bin
+```
+
+The whole slot comes out, 960 chunks of 2048 bytes on these models. On the run
+documented here that took about six minutes with no retries.
+
+**Verify it against something.** The point of the exercise is a file you can
+trust, so check it against an independent oracle rather than eyeballing it. If the
+cloud still serves your model's build, `docs/stock-firmware-catalogue.md` has the
+md5 - and a match proves the technique rather than merely producing plausible
+bytes. The `lamp9` `2.1.7_0031` extraction reproduced the catalogue md5
+`08f09790930817d39d02cb2d5dac1840` exactly, trailer included.
+
+**Do not truncate trailing `0xFF` to find the end of the image.** A slot is not
+image-then-erase-pattern. The updater erases only the sectors it writes, so
+whatever the *previous* firmware left beyond the current image is still there. The
+`lamp9` slot read back as:
+
+| region | contents |
+| ------ | -------- |
+| 0x000000 - 0x16CC43 | the image, plus its 4-byte CRC trailer |
+| 0x16CC44 - 0x16CFFF | `0xFF`, padding to the sector boundary |
+| 0x16D000 - 0x18FD8F | 142,736 bytes left over from an earlier, larger build |
+| 0x18FD90 - end | `0xFF` |
+
+Trimming trailing `0xFF` would have yielded 1,637,776 bytes - not the image, and
+not anything that would boot. Parse the ESP-IDF header instead:
+
+```
+python3 tools/parse_esp32_img.py stock.bin
+```
+
+which reports the segment structure, checks the appended SHA-256, and prints where
+the legitimate image ends and how many bytes follow it.
+
+Those leftover sectors are also worth a thought before sharing a raw slot dump:
+they contain fragments of whatever occupied the partition previously.
+
+### Putting a stock image back over the network
+
+ESPHome's own OTA accepts a foreign image, so a stock build can be written back
+the same way it came out - no UART, and no need for the device to still be paired
+to the cloud:
+
+```
+esphome upload --file stock.bin <device-config>.yaml --device <device-ip>
+```
+
+Underneath, this is an ordinary `OTA_TYPE_UPDATE_APP` write - unrestricted, and
+nothing to do with `allow_partition_access`. It targets
+`esp_ota_get_next_update_partition()`, so it lands in the slot the running build
+is not using; then `esp_ota_end()` runs `esp_image_verify()` and, if that passes,
+`esp_ota_set_boot_partition()` flips `otadata`. Both images survive - you end up
+with stock in one slot and ESPHome in the other, booting stock.
+
+Keep the CRC trailer on. It is what the vendor writes, and `esp_image_verify()`
+ignores bytes past the declared image end.
+
+Confirmed end to end on a `lamp9`: 1,494,084 bytes uploaded in 9.6 s, the device
+rebooted onto stock `2.1.7_0031`, TCP 55443 answered again, and - because NVS is
+untouched - the vendor app drove the lamp immediately without re-pairing. The
+image used was the one extracted from that same lamp, so what this demonstrates is
+the full round trip rather than a checksum.
+
+**How to test a restore honestly.** Writing stock into a slot that already holds
+byte-identical stock proves nothing: a write that did nothing at all would leave a
+valid stock image in place, `otadata` would still flip, and the device would still
+boot stock. Success and no-op are indistinguishable. Overwrite the target slot
+with something else first - flashing the ESPHome build a second time will do it,
+since that targets the inactive slot - and confirm the slot really changed by
+reading its first chunk back with `dump_flash`. Only then push the stock image.
+Booting stock afterwards has exactly one explanation.
+
+**The risk, stated plainly.** The good failure is `esp_image_verify()` rejecting
+the image: the OTA aborts and nothing changes. The bad failure is a written but
+unbootable image. These devices log `Bootloader too old for OTA rollback` at boot,
+so there is no automatic recovery from that - it means UART. Bounded, but real.
+
+### Replacing the partition table or bootloader
+
+**Not tested in this project.** What follows is what ESPHome documents as
+supported, recorded so the limits above are not mistaken for a hard boundary.
+Nothing in the procedures on this page exercises it, and upstream's own warning is
+that getting it wrong bricks the device past network recovery - which on these
+lamps means UART, and opening them.
+
+Everything else on this page writes only the application partition, using
+`OTA_TYPE_UPDATE_APP` (0x00), which needs no special permission. ESPHome also
+defines `OTA_TYPE_UPDATE_PARTITION_TABLE` (0x01) and `OTA_TYPE_UPDATE_BOOTLOADER`
+(0x02), gated behind an opt-in:
+
+```yaml
+ota:
+  - platform: esphome
+    allow_partition_access: true    # ESP32 only, default false
+```
+
+With that in the **running** build:
+
+```
+esphome upload --partition-table <device-config>.yaml --device <device-ip>
+esphome upload --bootloader      <device-config>.yaml --device <device-ip>
+```
+
+Four constraints worth knowing before planning around it:
+
+- The flag must already be on the device. Enabling it costs one ordinary app
+  flash first - and on a converted lamp that flash is the one that overwrites the
+  surviving stock slot, so sequence it deliberately.
+- The CLI refuses the options without the flag, and the device rejects the
+  handshake independently with "Device only supports app updates".
+- `--partition-table` and `--bootloader` cannot be combined, and neither works
+  over serial - they are OTA-only paths.
+- A newer bootloader is what would clear the `Bootloader too old for OTA rollback`
+  warning these devices log, and restore rollback protection. That is the obvious
+  motivation; it is also the change with the least margin for error, since a bad
+  bootloader leaves nothing to recover with.
 
 ## Appendix: why the obvious approach fails
 

--- a/docs/flashing-over-uart.md
+++ b/docs/flashing-over-uart.md
@@ -52,18 +52,23 @@ which is also the moment the boot log you wanted was printed.
 Three fixes, cheapest first:
 
 - **a separate 3.3V supply** for the board, adapter's VCC output switched off,
-  grounds common. A partially discharged 18650 works well: low internal
-  resistance, so the inrush is a non-issue.
+  grounds common. A **partially discharged** 18650 works well: low internal
+  resistance, so the inrush is a non-issue. Note **partially** - see the warning
+  below.
 - **bulk capacitance** across the board's 3.3V and GND, 100-470uF. Adapter
   regulators often have only ~22uF on the output, which is not enough to hold the
   rail through startup.
 - **a different USB port** - rear-panel rather than front-panel, or a powered hub.
   Sometimes the extra headroom is all it takes.
 
-> **If you use a lithium cell, measure it first.** The ESP32's absolute maximum on
-> `VDD33` is **3.6V**. A charged 18650 sits at **4.2V** and will destroy the chip.
-> A partially discharged cell around 3.4-3.5V is inside spec; the same cell after
-> a charge is not.
+> **If you use a lithium cell, measure it first - every time.** The ESP32's
+> absolute maximum on `VDD33` is **3.6V**. A **fully charged 18650 sits at 4.2V and
+> will destroy the chip**. A **partially discharged cell around 3.4-3.5V is inside
+> spec** - but the same cell after a charge is not, so a cell that was safe
+> yesterday is not necessarily safe today.
+>
+> A bare 18650 will also push tens of amps into a short, so keep the leads short,
+> insulate the unused end, and connect the negative last.
 
 ---
 
@@ -81,10 +86,17 @@ adapter RX. `esptool` needs the opposite direction, which a readable boot log sa
 nothing about. If the log works but nothing syncs, suspect the direction you have
 not exercised.
 
-**A continuity beeper will not sound through a series resistor.** These boards
-commonly put 100R between the debug pad and the module pin. A beeper trips below
-~50R, so it stays silent while the signal passes perfectly. **Measure resistance,
-not continuity**, and expect a finite value rather than a short.
+**A continuity beeper will not sound through a series resistor - and there is
+usually one on TX and RX.** These boards commonly put **100R in series on each
+UART line**, between the `TX`/`RX` debug pads and the module's `TXD0`/`RXD0` pins.
+A beeper trips below ~50R, so it stays silent while the signal passes perfectly.
+
+So "no beep from the pad to the module pin" does **not** mean the trace is broken.
+**Measure resistance, not continuity**, and expect roughly 100R rather than a
+short. On an ESP32-WROOM module the pins to check against are **34 (`RXD0`)** and
+**35 (`TXD0`)** - and a handy trick is to find `TXD0` first using the pad you know
+works, since the boot log proves that path, then check the other pad against its
+neighbour.
 
 **Close the terminal before running esptool.** Windows gives serial ports
 exclusively to one process. PuTTY holding the port produces

--- a/docs/flashing-over-uart.md
+++ b/docs/flashing-over-uart.md
@@ -1,0 +1,160 @@
+# Flashing over UART: the things that go wrong
+
+The per-model pinouts in the README tell you which pads to use. This is about
+what happens when you have wired them correctly and it still does not work.
+
+Everything here was hit in practice on a `yeelink.light.ceiling10`, using a
+CP2102 USB-serial adapter, and cost hours to work out. None of it is exotic; it
+is all first-timer territory, which is exactly why it is written down.
+
+---
+
+## The two that will actually stop you
+
+### 1. A common ground is not optional
+
+Tie the adapter's GND to the board's GND. If you power the board from a separate
+supply, all three grounds - adapter, supply, board - must be the same node.
+
+Without it you get a symptom that looks like anything but grounding:
+
+- the boot log **arrives perfectly** in your terminal
+- `esptool` reports `Serial data stream stopped: Possible serial noise or
+  corruption`
+- with `--trace`, it receives **a byte-perfect copy of the frame it just sent**
+
+The mechanism: signalling current needs a return path, and with no ground it
+returns through the *other* signal wire. Your own transmission appears at your own
+receiver. That is why the echo tracks whatever baud rate you pick - it *is* your
+signal, not a reply.
+
+How to recognise it in a trace. This is `esptool` sending SYNC and getting its own
+bytes back:
+
+```
+Write 46 bytes:  c0 00 08 24 00 00000000 07071220 5555...  c0
+Received full packet:  0008240000000000 0707122055555555 ...
+```
+
+Espressif's serial protocol specification is explicit that the ROM loader **never
+echoes the request**, and that a response always begins with direction byte
+`0x01`. A packet coming back with `0x00` - the *request* direction - is your own
+transmission, not an answer.
+
+### 2. The adapter's 3.3V rail may not start an ESP32
+
+An ESP32 draws a large current spike at power-on. Powering the board from the
+adapter's 3.3V pin can dip the USB 5V rail far enough to reset the USB-serial chip
+itself. The port then disappears and reappears, and your terminal says something
+like `Error reading from serial device` at the exact moment you switch power on -
+which is also the moment the boot log you wanted was printed.
+
+Three fixes, cheapest first:
+
+- **a separate 3.3V supply** for the board, adapter's VCC output switched off,
+  grounds common. A partially discharged 18650 works well: low internal
+  resistance, so the inrush is a non-issue.
+- **bulk capacitance** across the board's 3.3V and GND, 100-470uF. Adapter
+  regulators often have only ~22uF on the output, which is not enough to hold the
+  rail through startup.
+- **a different USB port** - rear-panel rather than front-panel, or a powered hub.
+  Sometimes the extra headroom is all it takes.
+
+> **If you use a lithium cell, measure it first.** The ESP32's absolute maximum on
+> `VDD33` is **3.6V**. A charged 18650 sits at **4.2V** and will destroy the chip.
+> A partially discharged cell around 3.4-3.5V is inside spec; the same cell after
+> a charge is not.
+
+---
+
+## Smaller traps, roughly in the order you meet them
+
+**Set the adapter to 3.3V logic, not 5V.** Many adapters have a selector for both
+VCC and the bus level. At 5V you put 5V into `GPIO3`. Check it before connecting
+anything.
+
+**Cross TX and RX.** Adapter TX to board RX, adapter RX to board TX. Worth stating
+because the next item makes a half-working setup look plausible.
+
+**Reading the boot log only proves one direction.** The log travels board TX ->
+adapter RX. `esptool` needs the opposite direction, which a readable boot log says
+nothing about. If the log works but nothing syncs, suspect the direction you have
+not exercised.
+
+**A continuity beeper will not sound through a series resistor.** These boards
+commonly put 100R between the debug pad and the module pin. A beeper trips below
+~50R, so it stays silent while the signal passes perfectly. **Measure resistance,
+not continuity**, and expect a finite value rather than a short.
+
+**Close the terminal before running esptool.** Windows gives serial ports
+exclusively to one process. PuTTY holding the port produces
+`could not open port 'COM3': PermissionError(13)`.
+
+**`GPIO0` is sampled at reset, not continuously.** Shorting it while the chip is
+already running does nothing. Ground it, *then* power on. Leaving it grounded for
+the whole session is fine and means an unexpected reset re-enters download mode
+rather than booting a half-written image. Espressif also require `GPIO2` to be low
+or floating for download mode; grounding it too is harmless.
+
+**Open the terminal before powering up.** The bootloader prints once, at reset. If
+the chip is already running you will see nothing until it resets.
+
+**Most adapters here cannot reset the chip for you.** `DTR`/`RTS` are not wired to
+the board's `EN`/`GPIO0`, so `esptool` cannot toggle download mode itself - power
+cycle by hand. Add `--before no-reset --after no-reset` if it complains about the
+reset it could not perform.
+
+---
+
+## Reading esptool's errors
+
+The wording is misleading, so it is worth knowing what the code actually checks
+(`esptool/loader.py`):
+
+| message | what it means |
+| ------- | ------------- |
+| `No serial data received.` | nothing came back at all |
+| `Serial data stream stopped: Possible serial noise or corruption.` | **one complete frame was read, then nothing more** - so something replied once and then went quiet |
+
+The second is not really about noise. Getting it after a byte-perfect echo means
+the "reply" was your own transmission and the chip never actually answered - see
+requirement 1 above.
+
+`--trace` is the tool that settles all of this. It prints every byte written and
+read, and the direction byte alone distinguishes "the chip answered" from "I am
+talking to myself".
+
+## A loopback test, and the trap in it
+
+Shorting the adapter's own TX to its own RX and typing in a terminal proves the
+adapter can send and receive: characters echo.
+
+The trap is using it to decide *where* a loop is. Disconnecting only the adapter's
+TX also stops the echo, because it removes the driver - whichever end is looping
+it. To test the adapter alone, **disconnect both wires from the board**, leave them
+plugged into the adapter and physically apart, and type. An echo then can only be
+the adapter.
+
+## Expect silence from a healthy ESPHome boot
+
+Configs here set `logger: baud_rate: 0`, which disables the UART logger. A working
+boot therefore looks like bootloader chatter and then **nothing**. That is success,
+not a hang - confirm it by looking for the device on your network.
+
+The bootloader's own output cannot be disabled, so it is always available for
+diagnosis regardless of what the application does.
+
+## Where to write, and how to get back
+
+Read the partition table before writing anything:
+
+```
+esptool read-flash 0x8000 0xc00 ptable.bin
+```
+
+Application images go to an OTA slot - `0x10000` on a `ceiling10` - **not** to
+`0x0`, which is the bootloader. `otadata` decides which slot boots, and stock
+survives in the slot the updater did not write, so reverting is usually a matter
+of pointing `otadata` back rather than reflashing. See
+[flashing-over-the-network.md](flashing-over-the-network.md) for the layout and
+the `otadata` mechanics.

--- a/docs/yeelink-light-lamp9-staria-pro.md
+++ b/docs/yeelink-light-lamp9-staria-pro.md
@@ -167,7 +167,27 @@ bootloader and partition table stay in place. ESPHome reports:
 ```
 
 Harmless in practice, but it costs around 40KB of IRAM and there is no OTA
-rollback protection. Only a UART flash replaces the bootloader.
+rollback protection.
+
+Replacing the bootloader would clear both, and ESPHome documents a way to do it
+over the air - but **it was not tested here**, so treat the following as what
+upstream supports rather than as something this project has done. Upstream's own
+warning is that getting it wrong bricks the device beyond network recovery, and
+on these lamps that means UART, which means opening them.
+
+The mechanism: `allow_partition_access: true` on the `esphome` OTA platform
+(ESP32 only, off by default) makes the device accept
+`OTA_TYPE_UPDATE_PARTITION_TABLE` and `OTA_TYPE_UPDATE_BOOTLOADER` alongside the
+ordinary `OTA_TYPE_UPDATE_APP`, which `esphome upload --partition-table` and
+`--bootloader` then send. Note the ordering trap: the flag has to be in the
+*running* build, so enabling it costs one ordinary flash first - the CLI refuses
+otherwise, and the device rejects the handshake with "Device only supports app
+updates". The two options are mutually exclusive and OTA-only; they are refused
+for serial uploads.
+
+What is verified on this device is the unrestricted half: `OTA_TYPE_UPDATE_APP`
+needs no such flag, and was used to write a stock image back over the network -
+see [flashing-over-the-network.md](flashing-over-the-network.md).
 
 ## Transition length
 

--- a/flash_probe.yaml
+++ b/flash_probe.yaml
@@ -1,0 +1,69 @@
+# Read-only flash instrumentation: keep a copy of the stock firmware.
+#
+# Include this from a device config BEFORE the first flash:
+#
+#     packages:
+#       flash_probe: !include flash_probe.yaml
+#
+# Why the timing matters. A flash always targets the OTA slot that is not
+# running, so converting to ESPHome leaves the vendor image intact in the other
+# slot - but only until the next flash, which targets exactly that slot. The
+# image that replaces stock is therefore the only one that can still read it.
+# Convert without this and the vendor copy is unreachable: gaining the ability
+# to read it costs the flash that destroys it.
+#
+# What it adds, all read-only - nothing here writes to flash:
+#
+#   dump_flash(offset, length)    read the inactive OTA slot, logged as base64
+#   dump_otadata(offset, length)  read the bootloader's slot-selection records
+#   log_slots                     which slot runs now, which the next OTA takes
+#   redump_config                 re-run dump_config, for the partition table
+#
+# Drive it with tools/dump_stock.py, which reassembles the chunks and is
+# restartable. See docs/flashing-over-the-network.md for the whole procedure,
+# including how to verify what you extracted.
+#
+# Cost: about 6 KB of RAM (a 2 KB read buffer, plus the larger log buffer) and
+# four actions visible on the device in Home Assistant. Remove the include again
+# once you have the image - but remember that doing so is itself a flash, and
+# after it the vendor slot is gone.
+#
+# Deliberately NOT `allow_partition_access`: that gates *writes* of the
+# partition table and bootloader and carries an explicit bricking warning.
+# Nothing here needs it.
+
+esphome:
+  includes:
+    - tools/probe_flash.h
+
+# A 2048-byte chunk is 2732 base64 characters and has to fit one log line.
+logger:
+  tx_buffer_size: 4096
+
+# Logs the full partition table at boot, plus chip revision, core count and
+# flash geometry.
+debug:
+
+api:
+  actions:
+    - action: dump_flash
+      variables:
+        offset: int
+        length: int
+      then:
+        - lambda: flash_probe::dump_flash(offset, length);
+
+    - action: dump_otadata
+      variables:
+        offset: int
+        length: int
+      then:
+        - lambda: flash_probe::dump_otadata(offset, length);
+
+    - action: log_slots
+      then:
+        - lambda: flash_probe::log_slots();
+
+    - action: redump_config
+      then:
+        - lambda: App.schedule_dump_config();

--- a/tools/dump_stock.py
+++ b/tools/dump_stock.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Read the inactive OTA slot off a probe-firmware lamp, over the network.
+
+The lamp runs the probe build in one slot; the vendor's stock image is still in
+the other, because a flash always targets the inactive slot and only one flash
+has happened. `dump_flash(offset, length)` on the probe reads that slot and logs
+the bytes as base64, so the image can be recovered with no UART and no teardown -
+which is what makes it usable on a device still under warranty.
+
+Restartable by construction: the output file is preallocated to the partition
+size and a sidecar records which offsets have landed, so an interrupted run
+picks up where it stopped rather than starting over.
+
+Usage:
+    dump_stock.py <ip> <out.bin> [--size BYTES] [--chunk BYTES]
+"""
+
+import argparse
+import asyncio
+import base64
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+CHUNK_LINE = re.compile(r"CHUNK (\d+) (\d+) (\S+)")
+
+PART_SIZE = 0x1E0000          # miio_fw1 / miio_fw2 on lamp9
+CHUNK = 2048                  # MAX_CHUNK in probe_flash.h
+
+
+async def run(ip: str, out: pathlib.Path, size: int, chunk: int) -> int:
+    from aioesphomeapi import APIClient, LogLevel
+
+    done_path = out.with_suffix(out.suffix + ".done")
+    done = set()
+    if out.is_file() and done_path.is_file():
+        done = {int(x) for x in done_path.read_text().split() if x}
+        print(f"resuming: {len(done)} chunks already stored")
+    else:
+        out.write_bytes(b"\x00" * size)
+        done_path.write_text("")
+
+    fh = out.open("r+b")
+    dfh = done_path.open("a")
+
+    cli = APIClient(ip, 6053, None)
+    await cli.connect(login=True)
+    try:
+        _entities, services = await cli.list_entities_services()
+        svc = {s.name: s for s in services}
+        if "dump_flash" not in svc:
+            raise SystemExit(f"{ip} does not expose dump_flash - is the probe build running?")
+
+        got: dict[int, bytes] = {}
+
+        def on_log(msg):
+            m = CHUNK_LINE.search(ANSI.sub("", msg.message.decode(errors="replace")))
+            if m:
+                got[int(m.group(1))] = base64.b64decode(m.group(3))
+
+        cli.subscribe_logs(on_log, log_level=LogLevel.LOG_LEVEL_DEBUG)
+        await asyncio.sleep(1)
+
+        offsets = [o for o in range(0, size, chunk) if o not in done]
+        total, failed = len(offsets), []
+        for i, off in enumerate(offsets, 1):
+            for attempt in range(4):
+                got.pop(off, None)
+                await cli.execute_service(svc["dump_flash"], {"offset": off, "length": chunk})
+                for _ in range(60):                      # up to ~3 s
+                    await asyncio.sleep(0.05)
+                    if off in got:
+                        break
+                if off in got:
+                    break
+                print(f"  retry {attempt + 1} at offset {off}")
+            if off not in got:
+                failed.append(off)
+                continue
+            fh.seek(off)
+            fh.write(got.pop(off))
+            dfh.write(f"{off}\n")
+            if i % 50 == 0 or i == total:
+                dfh.flush()
+                fh.flush()
+                print(f"  {i}/{total} chunks  ({off + chunk}/{size} bytes)", flush=True)
+        fh.flush()
+        dfh.flush()
+        if failed:
+            print(f"FAILED offsets ({len(failed)}): {failed[:20]}")
+        return len(failed)
+    finally:
+        await cli.disconnect()
+        fh.close()
+        dfh.close()
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("ip")
+    p.add_argument("out")
+    p.add_argument("--size", type=lambda x: int(x, 0), default=PART_SIZE)
+    p.add_argument("--chunk", type=lambda x: int(x, 0), default=CHUNK)
+    a = p.parse_args()
+    sys.exit(asyncio.run(run(a.ip, pathlib.Path(a.out), a.size, a.chunk)))

--- a/tools/parse_esp32_img.py
+++ b/tools/parse_esp32_img.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Parse an ESP-IDF app image; report structure and any trailing bytes past the
+end of the legitimate image (i.e. whatever Xiaomi's 'crc' step appends)."""
+import binascii
+import hashlib
+import struct
+import sys
+
+path = sys.argv[1]
+data = open(path, "rb").read()
+print(f"file: {path}")
+print(f"size: {len(data)} bytes")
+
+if data[0] != 0xE9:
+    print(f"!! first byte 0x{data[0]:02x}, not 0xE9 — not a raw ESP-IDF image")
+    sys.exit(0)
+
+seg_count = data[1]
+entry = struct.unpack("<I", data[4:8])[0]
+chip_id = struct.unpack("<H", data[12:14])[0]
+hash_appended = data[23]
+print(f"header: segments={seg_count} entry=0x{entry:08x} chip_id={chip_id} "
+      f"hash_appended={hash_appended}")
+
+off = 24
+for i in range(seg_count):
+    load_addr, seg_len = struct.unpack("<II", data[off:off + 8])
+    off += 8 + seg_len
+
+pad = 15 - (off % 16)
+off += pad + 1
+if hash_appended == 1:
+    sha_off = off
+    stored = binascii.hexlify(data[sha_off:sha_off + 32]).decode()
+    calc = hashlib.sha256(data[:sha_off]).hexdigest()
+    off += 32
+    print(f"SHA-256 stored : {stored}")
+    print(f"SHA-256 calc   : {calc}")
+    print(f"SHA-256 {'MATCHES' if stored == calc else 'MISMATCH'}")
+
+print(f"legitimate image ends at {off} (0x{off:x})")
+trailer = data[off:]
+print(f"trailing bytes: {len(trailer)}" + (f"  hex={binascii.hexlify(trailer).decode()}" if trailer else "  (none)"))

--- a/tools/probe_flash.h
+++ b/tools/probe_flash.h
@@ -1,0 +1,88 @@
+// Read-only flash instrumentation for a Yeelight being converted to ESPHome.
+//
+// Everything here reads; nothing writes. The target is the INACTIVE OTA slot -
+// esp_ota_get_next_update_partition() returns the slot this build is NOT running
+// from, which is where the vendor image still sits after a single flash. Reading
+// it out over the API is what makes a stock image recoverable without UART, and
+// therefore usable on a device still under warranty.
+//
+// Chunks are logged as base64 on one line, so the caller can reassemble them
+// from an API log subscription. 2048 raw bytes expand to 2732 characters, which
+// is why flash_probe.yaml raises tx_buffer_size to 4096.
+//
+// Pulled in by flash_probe.yaml; driven by tools/dump_stock.py.
+#pragma once
+
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
+
+#include "esphome/core/alloc_helpers.h"
+#include "esphome/core/log.h"
+
+namespace flash_probe {
+
+static const char *const TAG = "probe";
+static constexpr size_t MAX_CHUNK = 2048;
+
+inline void log_part(const char *what, const esp_partition_t *p) {
+  if (p == nullptr) {
+    ESP_LOGI(TAG, "%s: none", what);
+    return;
+  }
+  ESP_LOGI(TAG, "%s: label=%s type=0x%02x subtype=0x%02x addr=0x%06" PRIx32 " size=0x%06" PRIx32,
+           what, p->label, p->type, p->subtype, p->address, p->size);
+}
+
+/// Which slot is running and which one the next OTA would overwrite. Confirms
+/// the alternation first-hand rather than taking it from the documentation.
+inline void log_slots() {
+  log_part("running", esp_ota_get_running_partition());
+  log_part("boot", esp_ota_get_boot_partition());
+  log_part("next_update", esp_ota_get_next_update_partition(nullptr));
+  log_part("otadata", esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
+                                               ESP_PARTITION_SUBTYPE_DATA_OTA, nullptr));
+}
+
+inline void dump_part(const esp_partition_t *part, const char *what, int offset, int length) {
+  if (part == nullptr) {
+    ESP_LOGW(TAG, "%s: partition not found", what);
+    return;
+  }
+  if (offset < 0 || length <= 0) {
+    ESP_LOGW(TAG, "%s: bad request offset=%d length=%d", what, offset, length);
+    return;
+  }
+  if ((size_t) offset >= part->size) {
+    ESP_LOGW(TAG, "%s: offset %d past end 0x%06" PRIx32, what, offset, part->size);
+    return;
+  }
+  size_t len = (size_t) length > MAX_CHUNK ? MAX_CHUNK : (size_t) length;
+  if ((size_t) offset + len > part->size)
+    len = part->size - (size_t) offset;
+
+  static uint8_t buf[MAX_CHUNK];
+  const esp_err_t err = esp_partition_read(part, (size_t) offset, buf, len);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "%s: read at %d failed: %s", what, offset, esp_err_to_name(err));
+    return;
+  }
+  // One line per chunk: tag, offset, length, base64. The offset is echoed so a
+  // reassembling caller never has to trust the order lines arrive in.
+  ESP_LOGI(TAG, "%s %d %u %s", what, offset, (unsigned) len,
+           esphome::base64_encode(buf, len).c_str());
+}
+
+/// The inactive OTA slot - the vendor image, after exactly one flash.
+inline void dump_flash(int offset, int length) {
+  dump_part(esp_ota_get_next_update_partition(nullptr), "CHUNK", offset, length);
+}
+
+/// otadata, where the bootloader keeps the sequence numbers that decide which
+/// slot boots. Separate partition, so it needs its own reader.
+inline void dump_otadata(int offset, int length) {
+  dump_part(esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
+                                     ESP_PARTITION_SUBTYPE_DATA_OTA, nullptr),
+            "OTADATA", offset, length);
+}
+
+}  // namespace flash_probe

--- a/yeelight_light_ceil26.yaml
+++ b/yeelight_light_ceil26.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceil26
 

--- a/yeelight_light_ceil29.yaml
+++ b/yeelight_light_ceil29.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceil29
 

--- a/yeelight_light_ceila.yaml
+++ b/yeelight_light_ceila.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceila
   warm_max_power: "0.75"

--- a/yeelight_light_ceilb.yaml
+++ b/yeelight_light_ceilb.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceilb
 

--- a/yeelight_light_ceilc.yaml
+++ b/yeelight_light_ceilc.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceilc
 

--- a/yeelight_light_ceiling10.yaml
+++ b/yeelight_light_ceiling10.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling10
 

--- a/yeelight_light_ceiling11.yaml
+++ b/yeelight_light_ceiling11.yaml
@@ -2,6 +2,19 @@
 # - https://github.com/syssi/esphome-yeelight-ceiling-light/blob/main/yeelight_light_ceiling15.yaml
 # - https://github.com/jaddel/ESPHome-Configurations/blob/master/Devices/Ceiling%20Yeelight%20YLXD41YL/ceiling_yeelight_ylxd41xl.yaml
 
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling11
 

--- a/yeelight_light_ceiling15.yaml
+++ b/yeelight_light_ceiling15.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling15
 

--- a/yeelight_light_ceiling20.yaml
+++ b/yeelight_light_ceiling20.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling20
 

--- a/yeelight_light_ceiling22.yaml
+++ b/yeelight_light_ceiling22.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling22
 

--- a/yeelight_light_ceiling24.yaml
+++ b/yeelight_light_ceiling24.yaml
@@ -1,6 +1,19 @@
 # configuration based on:
 # - https://github.com/syssi/esphome-yeelight-ceiling-light/blob/main/yeelight_light_ceiling15.yaml
 
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-ceiling24
 

--- a/yeelight_light_fancl5.yaml
+++ b/yeelight_light_fancl5.yaml
@@ -1,6 +1,19 @@
 # Yeelight C900 LED Silent Ceiling Fan
 # YLFD002 / YLFD008
 
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-fancl5
   external_components_source: github://syssi/esphome-yeelight-ceiling-light@main

--- a/yeelight_light_lamp9.yaml
+++ b/yeelight_light_lamp9.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-lamp9
 

--- a/yeelight_light_lamp9_pro.yaml
+++ b/yeelight_light_lamp9_pro.yaml
@@ -17,6 +17,19 @@
 # Verified on a unit with production date 2020-10, ESP32-WROOM-32D. Other
 # revisions may differ - see the hardware notes before assuming the GPIO map.
 
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-lamp9-pro
 

--- a/yeelight_light_strip6.yaml
+++ b/yeelight_light_strip6.yaml
@@ -1,3 +1,16 @@
+# Keeping a copy of the stock firmware: uncomment BEFORE the first flash.
+#
+# A flash always targets the OTA slot that is not running, so this conversion
+# leaves the vendor image intact in the other slot - but only until the next
+# flash, which targets exactly that slot. This image is therefore the only one
+# that can still read it. Convert without this and the copy is gone: gaining the
+# ability to read it costs the flash that destroys it.
+#
+# Read-only; see flash_probe.yaml and docs/flashing-over-the-network.md.
+#
+# packages:
+#   flash_probe: !include flash_probe.yaml
+
 substitutions:
   name: yeelight-light-strip6
 


### PR DESCRIPTION
## What this adds

Converting one of these lamps over the network leaves the vendor image intact in the other OTA slot — but only until the next flash, which targets exactly that slot. So **the ESPHome image that replaces stock is the only one that can ever read it.** That makes keeping a copy a first-flash decision, not a recovery step: convert with a plain config and the copy is unreachable, because gaining the ability to read it costs the flash that destroys it.

This adds the read-side instrumentation to make that possible, and documents the round trip:

1. **`flash_probe.yaml`** — four read-only API actions (`dump_flash`, `dump_otadata`, `log_slots`, `redump_config`), implemented in `tools/probe_flash.h`. Commented out in every lamp config, so nothing changes by default, but the line sits in the file people already open to set their secrets, at the moment the decision has to be made. Deliberately does **not** enable `allow_partition_access`.
2. **`tools/dump_stock.py`** — drives the read loop and reassembles the chunks; restartable, since a 1,966,080-byte slot is 960 round trips.
3. **`tools/parse_esp32_img.py`** — finds where an image actually ends.
4. Docs for extracting the image, verifying it, and writing it back with `esphome upload --file`.

## What is verified

On a `yeelink.light.lamp9` running `2.1.7_0031`:

- Extraction reproduces the cloud catalogue md5 `08f09790930817d39d02cb2d5dac1840` exactly, trailer included — an independent oracle, so this proves the technique rather than producing plausible bytes.
- Restoring **that extracted file** brought the lamp back on TCP 55443 with the vendor app driving it, no re-pairing, since NVS is untouched. Full round trip, not just a checksum.
- The `lamp9` partition table now dumped (over the network) and **identical** to the `ceiling10` one already documented — two data points, said as such.
- `otadata` behaves as documented: seq 4 vs 3, `ota_state 0x02`, selecting `ota_[(seq-1) % 2]`.

Three things that correct or extend the existing docs:

- **The CRC trailer is stored in flash**, not consumed by the updater, and `esp_image_verify()` accepts an image that still carries it.
- **A slot is not image-then-erase-pattern.** The updater erases only the sectors it writes, so trimming trailing `0xFF` yielded 1,637,776 bytes rather than the image — 142,736 bytes of an older build were still there past a gap. Parse the header instead.
- **"Only a UART flash replaces the bootloader" was wrong as written.** `OTA_TYPE_UPDATE_PARTITION_TABLE` / `OTA_TYPE_UPDATE_BOOTLOADER` exist behind `allow_partition_access`. Nothing here exercised them, so they are written as documented-but-untested with upstream's bricking warning kept, rather than replaced by an equally unverified claim in the other direction.

## Also on this branch: UART and network flashing docs

**`docs/flashing-over-uart.md`** (new) — the per-model pinouts in the README say which pads to use; this covers what happens when they are wired correctly and it still does not work. All of it hit in practice on a `ceiling10` with a CP2102.

The two that actually stop people:

- **A common ground is not optional.**
- **The adapter's 3.3V rail may not start an ESP32.** The power-on current spike can dip the USB 5V rail far enough to reset the USB-serial chip itself, so the port disappears at exactly the moment the boot log you wanted was printed. Three fixes, cheapest first.

Then the smaller traps in the order you meet them, including two that make a broken setup look plausible:

- **A readable boot log only proves one direction.** It travels board TX → adapter RX; `esptool` needs the opposite. If the log works but nothing syncs, suspect the direction you have not exercised.
- **A continuity beeper will not sound through a series resistor**, and these boards commonly put **100R in series on each UART line** between the debug pads and the module's `TXD0`/`RXD0`. A beeper trips below ~50R, so it stays silent while the signal passes perfectly.

Plus reading `esptool`'s errors, the loopback test and the trap in it, why a healthy ESPHome boot is silent, where to write, and how to get back.

**`docs/flashing-over-the-network.md`** also gained, before the work above:

- The partition-table MD5 requirement and OTA-slot recovery.
- The CRC trailer documented as enforced rather than assumed, with the observed rejection: three full-size GETs and back to `idle`, which is visible without a serial console.
- The single-core build as a numbered requirement, saying what was actually tested.
- Each requirement attributed to the device it was observed on, since `lamp9` and `ceiling10` differ.
- A restructure to lead with what works and move the background to an appendix.
- Where configuration lives — one shared `nvs` partition outside both app slots, which is why the vendor firmware comes back already knowing its credentials, and why `factory_reset` is worth keeping out of a config on a device you intend to return to stock.

## Notes for review

- The commented include touches 15 configs identically. Left out of `yeerc_*` and `yeedimmer_*`, which are receivers for BLE devices and have no `miio_fw` slots.
- Verified that uncommenting the include compiles cleanly (`yeelight_light_lamp9_pro.yaml`, ESP-IDF, 2026.6.5).
- Cost when enabled: ~6 KB RAM and four actions on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
